### PR TITLE
Let CompatHelper ride on the latest Julia version

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: julia-actions/setup-julia@latest
         with:
-          version: 1.5
+          version: 1
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: CompatHelper.main()


### PR DESCRIPTION
That way you wouldn't have to bump it. Not necessarily required but something to think about.