### PR TITLE
Verify integrators, fix McLachlan4, add Yoshida6/8 and convergence tests

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -66,7 +66,7 @@ makedocs(
             # "CGVI"        => "integrators/cgvi.md",
             # "DGVI"        => "integrators/dgvi.md",
             "Hamilton-Pontryagin" => "integrators/hpi.md",
-            # "Hamilton-Pontryagin-Galerkin" => "integrators/hpg.md",
+            "Hamilton-Pontryagin-Galerkin" => "integrators/hpg.md",
         ],
         "Modules" => [
             # "Discontinuities"     => "modules/discontinuities.md",

--- a/docs/src/GeometricIntegrators.bib
+++ b/docs/src/GeometricIntegrators.bib
@@ -443,3 +443,59 @@
     pages   = {1042-1071},
     doi     = {10.1002/mma.2863}
 }
+
+@article{Yoshimura:2006a,
+	author = {Yoshimura, Hiroaki and Marsden, Jerrold E.},
+	title = {{Dirac structures in Lagrangian mechanics Part I: Implicit Lagrangian systems}},
+	journal = {Journal of Geometry and Physics},
+	year = {2006},
+	volume = {57},
+	pages = {133--156},
+	doi = {10.1016/j.geomphys.2006.02.009}
+}
+
+@article{Yoshimura:2006b,
+	author = {Yoshimura, Hiroaki and Marsden, Jerrold E.},
+	title = {{Dirac structures in Lagrangian mechanics Part II: Variational structures}},
+	journal = {Journal of Geometry and Physics},
+	year = {2006},
+	volume = {57},
+	pages = {209--250},
+	doi = {10.1016/j.geomphys.2006.02.012}
+}
+
+@article{BouRabee:2009,
+	author = {Bou-Rabee, Nawaf and Marsden, Jerrold E.},
+	title = {{Hamilton--Pontryagin Integrators on Lie Groups Part I: Introduction and Structure-Preserving Properties}},
+	journal = {Foundations of Computational Mathematics},
+	year = {2009},
+	volume = {9},
+	pages = {197--219},
+	doi = {10.1007/s10208-008-9030-4}
+}
+
+@unpublished{Tyranowski:2014linear,
+	author = {Tyranowski, Tomasz M. and Desbrun, Mathieu},
+	title = {{Variational Partitioned Runge--Kutta Methods for Lagrangians Linear in Velocities}},
+	year = {2014},
+	note = {arXiv:1401.7904},
+	eprint = {1401.7904},
+	eprinttype = {arxiv}
+}
+
+@article{Ellison:2018,
+	author = {Ellison, C. L. and Finn, J. M. and Burby, J. W. and Kraus, M. and Qin, H. and Tang, W. M.},
+	title = {{Degenerate variational integrators for magnetic field line flow and guiding center trajectories}},
+	journal = {Physics of Plasmas},
+	year = {2018},
+	volume = {25},
+	pages = {052502},
+	doi = {10.1063/1.5022277}
+}
+
+@unpublished{Kraus:2019,
+	author = {Kraus, Michael},
+	title = {{Symplectic Runge-Kutta Methods for Certain Degenerate Lagrangian Systems}},
+	year = {2019},
+	note = {Unpublished manuscript}
+}

--- a/docs/src/integrators/dvi.md
+++ b/docs/src/integrators/dvi.md
@@ -1,3 +1,127 @@
+```@meta
+CurrentModule = GeometricIntegrators.Integrators
+```
 
-# Degenerate Variational Integrators
+# [Degenerate Variational Integrators](@id dvi)
 
+Many important systems in physics are described by *degenerate* Lagrangians, in
+particular Lagrangians that are linear in the velocities,
+```math
+\begin{equation}\label{eq:dvi-degenerate-lagrangian}
+L (q, \dot{q}) = \vartheta (q) \cdot \dot{q} - H(q) ,
+\end{equation}
+```
+where $\vartheta$ is in general a nonlinear function of $q$. The Hessian
+$\partial^2 L / \partial \dot{q} \, \partial \dot{q}$ vanishes identically, so
+the Lagrangian is maximally degenerate. Such Lagrangians arise, for example, for
+Lotka–Volterra models, various nonlinear oscillators, and guiding-centre and
+other reduced charged-particle dynamics.
+
+Standard variational (VPRK) integrators, see the [VPRK page](@ref vprk), are
+applicable when $\vartheta$ is a linear function of $q$, but are often found to be
+unstable when $\vartheta$ is nonlinear [[Kraus:2017](@cite)]. Two remedies exist:
+projected variational integrators (see the projection methods), and the
+*degenerate variational integrators* described here, which are constructed
+directly for Lagrangians of the form \eqref{eq:dvi-degenerate-lagrangian}.
+
+GeometricIntegrators.jl provides the following degenerate variational
+integrators:
+
+| Method              | Description                                                | Order |
+|:--------------------|:-----------------------------------------------------------|:------|
+| [`DVIA`](@ref)      | Symplectic-Euler-A type degenerate variational integrator  | 1     |
+| [`DVIB`](@ref)      | Symplectic-Euler-B type degenerate variational integrator  | 1     |
+| [`CMDVI`](@ref)     | Midpoint (centred) degenerate variational integrator       | 2     |
+| [`CTDVI`](@ref)     | Trapezoidal degenerate variational integrator              | 2     |
+| [`DVRK`](@ref)      | Degenerate variational Runge–Kutta method                  | 2s    |
+
+
+## Euler-Type and Midpoint/Trapezoidal Integrators
+
+For definiteness we split the coordinates as $q = (x^1, x^2)$, where only the
+first half of the components appear in the symplectic potential, so that the
+Lagrangian takes the form
+```math
+L (x^1, x^2, \dot{x}^1, \dot{x}^2) = \vartheta_1 (x^1, x^2) \cdot \dot{x}^1 - H(x^1, x^2) .
+```
+The degenerate variational integrators are obtained from a discrete action
+principle that preserves this degeneracy [[Ellison:2018](@cite)]. Applying the
+discrete (Type I) phase-space action principle and introducing the velocity
+$v^1_n = (x^1_{n+1} - x^1_{n}) / h$ leads to the equations of motion
+```math
+\begin{equation}\label{eq:dvi-eqs-of-motion}
+\begin{aligned}
+\dfrac{\vartheta_1 (x^1_{n}, x^2_{n}) - \vartheta_1 (x^1_{n-1}, x^2_{n-1})}{h}
+  &= \nabla_{1} \vartheta_1 (x^1_{n}, x^2_{n}) \cdot v^1_{n} - \nabla_{1} H (x^1_{n}, x^2_{n}) , \\
+v^1_{n} &= \big( \nabla_{2} \vartheta_1 (x^1_{n}, x^2_{n}) \big)^{-1} \nabla_{2} H (x^1_{n}, x^2_{n}) , \\
+\dfrac{x^1_{n+1} - x^1_{n}}{h} &= v^1_{n} ,
+\end{aligned}
+\end{equation}
+```
+under an appropriate invertibility condition on $\nabla_2 \vartheta_1$. The
+[`DVIA`](@ref) and [`DVIB`](@ref) integrators correspond to the two
+symplectic-Euler-type discretisations of this principle (evaluating $\vartheta$
+and $H$ at the beginning or the end of the interval) and are first order. The
+[`CMDVI`](@ref) and [`CTDVI`](@ref) integrators use, respectively, a midpoint and
+a trapezoidal discretisation and are symmetric and second order.
+
+These integrators are only applicable to Lagrangians of the special form above
+and are of low order; a variational construction of higher-order methods for
+general degenerate Lagrangians is not currently known [[Ellison:2018](@cite)].
+A higher-order, non-variational alternative is provided by the degenerate
+variational Runge–Kutta methods described next.
+
+
+## Degenerate Variational Runge–Kutta Methods
+
+The [`DVRK`](@ref) methods are symplectic Runge–Kutta integrators applicable to
+the degenerate Lagrangians \eqref{eq:dvi-degenerate-lagrangian}
+[[Kraus:2019](@cite)]. Given a Runge–Kutta tableau with coefficients $a_{ij}$,
+weights $b_{i}$ and nodes $c_{i}$, the internal stages are
+```math
+\begin{equation}\label{eq:dvrk}
+\begin{aligned}
+Q_{n,i} &= q_{n} + h \sum \limits_{j=1}^{s} a_{ij} \, V_{n,j} , &
+P_{n,i} &= \dfrac{\partial L}{\partial v} (Q_{n,i}, V_{n,i}) = \vartheta (Q_{n,i}) , \\
+P_{n,i} &= p_{n} + h \sum \limits_{j=1}^{s} a_{ij} \, F_{n,j} , &
+F_{n,i} &= \dfrac{\partial L}{\partial q} (Q_{n,i}, V_{n,i}) ,
+\end{aligned}
+\end{equation}
+```
+and the update reads
+```math
+\begin{aligned}
+q^{\mu}_{n+1} &= q^{\mu}_{n} + h \sum \limits_{i=1}^{s} b_{i} \, V^{\mu}_{n,i} , &
+p^{\mu}_{n+1} &= p^{\mu}_{n} + h \sum \limits_{i=1}^{s} b_{i} \, F^{\mu}_{n,i} ,
+&& \mu = 1, \, ..., \, d/2 , \\
+&&
+p^{\mu}_{n+1} &= \vartheta^{\mu} (q_{n+1}) , && \mu = 1, \, ..., \, d .
+\end{aligned}
+```
+For systems of the form \eqref{eq:dvi-degenerate-lagrangian} this method is
+symplectic provided the coefficient matrix $A = (a_{ij})$ is invertible, the
+coefficients satisfy the symplecticity relation
+```math
+\begin{equation}\label{eq:dvrk-symplecticity}
+b_{i} a_{ij} + b_{j} a_{ji} = b_{i} b_{j}
+\qquad \text{for all} \qquad i, j = 1, \, ..., \, s ,
+\end{equation}
+```
+and the momentum is initialised consistently with $p_{0} = \vartheta (q_{0})$
+[[Kraus:2019](@cite)]. Using Gauss–Legendre coefficients (`DVRK(Gauss(s))`)
+yields a method of order $2s$.
+
+!!! note
+    The single-tableau form \eqref{eq:dvrk}–\eqref{eq:dvrk-symplecticity} follows
+    [[Kraus:2019](@cite)]. The implementation accepts any
+    [`Tableau`](@ref) and additionally supports a second (embedded) set of
+    coefficients $\bar{a}_{ij}, \bar{b}_{i}$, for which the general symplecticity
+    conditions read $b_{i} \bar{a}_{ij} + \bar{b}_{j} a_{ji} = b_{i} \bar{b}_{j}$
+    and $\bar{b}_{i} = b_{i}$; these reduce to \eqref{eq:dvrk-symplecticity} when
+    $\bar{a} = a$ and $\bar{b} = b$.
+
+A `DVRK` integrator is constructed by passing a Runge–Kutta tableau or method:
+```
+DVRK(tableau::Tableau)
+DVRK(method::RKMethod)
+```

--- a/docs/src/integrators/hpg.md
+++ b/docs/src/integrators/hpg.md
@@ -1,1 +1,133 @@
+```@meta
+CurrentModule = GeometricIntegrators.Integrators
+```
+
 # [Hamilton-Pontryagin-Galerkin Integrators](@id hpg)
+
+!!! note
+    The Hamilton–Pontryagin–Galerkin (HPG) framework described on this page is
+    not yet implemented in GeometricIntegrators.jl. This page documents the
+    theory that underlies the closely related, finite-difference
+    [Hamilton–Pontryagin integrators](@ref hpi) (`HPImidpoint`, `HPItrapezoidal`),
+    which arise as particular low-order instances of the framework.
+
+Hamilton–Pontryagin–Galerkin integrators are obtained from a discontinuous
+Galerkin discretisation of the Hamilton–Pontryagin principle. Whereas the
+construction of a variational integrator usually involves two ingredients — a
+finite-dimensional function space that approximates the phase-space trajectories,
+and a quadrature rule that approximates the action integral — the HPG framework
+adds a third ingredient, a *continuity constraint* or *jump condition* that
+connects the (possibly broken) function spaces across time nodes. Many known
+variational integrators, obtained from distinct variational principles, emerge as
+special cases of this unifying framework, including the discrete Euler–Lagrange
+equations, the position-momentum form, the symplectic Euler and Störmer–Verlet
+methods, and symplectic and variational Runge–Kutta methods.
+
+
+## Continuous Hamilton–Pontryagin Principle
+
+The Hamilton–Pontryagin principle [[Yoshimura:2006b](@cite)] is an action
+principle on the Pontryagin bundle $TQ \oplus T^*Q$. In contrast to Hamilton's
+principle of stationary action, where the variations $\delta v$ are induced by
+variations $\delta q$, here the variations of the velocity $v$ are left free.
+Instead, a kinematic constraint enforcing the second-order condition $v = \dot{q}$
+is added, with the momentum $p$ acting as a Lagrange multiplier,
+```math
+\begin{equation}\label{eq:hpg-continuous-action}
+\mathcal{A} [q,v,p] = \int \limits_{0}^{T} \Big[ L(q,v) + \left< p , \dot{q} - v \right> \Big] \, dt .
+\end{equation}
+```
+Computing variations,
+```math
+\delta \mathcal{A} [q,v,p] = \int \limits_{0}^{T} \bigg[ \frac{\partial L}{\partial q} \, \delta q + \frac{\partial L}{\partial v} \, \delta v + \left< \delta p , \dot{q} - v \right> + \left< p , \delta \dot{q} - \delta v \right> \bigg] \, dt = 0 ,
+```
+yields the second-order condition, the Legendre transform, and the
+Euler–Lagrange equations,
+```math
+\begin{aligned}
+\dot{q} &= v , &
+p &= \frac{\partial L}{\partial v} (q,v) , &
+\dot{p} &= \frac{\partial L}{\partial q} (q,v) .
+\end{aligned}
+```
+Equivalently, introducing the generalised energy $E(q,v,p) = \left< p, v \right> - L(q,v)$, the principle can be written as
+```math
+\mathcal{A} [q,v,p] = \int \limits_{0}^{T} \Big[ \left< p, \dot{q} \right> - E(q,v,p) \Big] \, dt ,
+```
+whose variations lead to a set of generalised Hamilton equations
+```math
+\begin{aligned}
+\dot{q} &= \frac{\partial E}{\partial p} (q,v,p) , &
+\frac{\partial E}{\partial v} &= 0 , &
+\dot{p} &= - \frac{\partial E}{\partial q} (q,v,p) .
+\end{aligned}
+```
+For constrained systems, the Hamilton–Pontryagin principle generalises to the
+Lagrange–d'Alembert–Pontryagin principle [[Yoshimura:2006a](@cite), [Yoshimura:2006b](@cite)].
+
+
+## Galerkin Discretisation
+
+The trajectories $\big( q(t), v(t), p(t) \big)$ on the Pontryagin bundle are
+approximated by piecewise polynomials on a fixed time interval $\mathcal{I} = [0, T]$,
+partitioned into $N$ subintervals $\mathcal{I}_{n} = (t_{n}, t_{n+1})$ with
+$t_{n} = nh$ and fixed time step $h$. On each subinterval, $q$, $v$ and $p$ are
+represented by polynomials of degree $r_q$, $r_v$ and $r_p$,
+```math
+Q_{n} (t) = \sum \limits_{i=1}^{r_{q}} Q_{n,i} \, \varphi_{n,i}^{q} (t) ,
+\qquad
+V_{n} (t) = \sum \limits_{i=1}^{r_{v}} V_{n,i} \, \varphi_{n,i}^{v} (t) ,
+\qquad
+P_{n} (t) = \sum \limits_{i=1}^{r_{p}} P_{n,i} \, \varphi_{n,i}^{p} (t) ,
+```
+with basis functions $\varphi_{n,i}$, e.g. Lagrange polynomials, and quadrature
+nodes $c_{i}$ with weights $b_{i}$ (satisfying $\sum_{i=1}^{s} b_{i} = 1$),
+located at $t_{n,i} = t_{n} + h c_{i}$. With this data the discrete
+Hamilton–Pontryagin action \eqref{eq:hpg-continuous-action} becomes
+```math
+\begin{multline}\label{eq:hpg-discrete-action}
+\mathcal{A}_{d} [Q,V,P] = h \sum \limits_{n=0}^{N-1} \Bigg[
+\sum \limits_{i=1}^{s} b_{i} \Big( L \big( Q_{n} (t_{n,i}) , V_{n} (t_{n,i}) \big)
++ \big< P_{n} (t_{n,i}) , \, \dot{Q}_{n} (t_{n,i}) - V_{n} (t_{n,i}) \big> \Big) \\
++ \text{(continuity constraints or numerical flux)} \Bigg] .
+\end{multline}
+```
+Since the function spaces may be broken, the values of the polynomials $Q_n$ and
+$Q_{n+1}$ at a shared node $t_{n+1}$ need not coincide; they are denoted by the
+one-sided limits $q_{n+1}^{-}$ and $q_{n+1}^{+}$, and analogously for $v$ and $p$.
+For continuous discretisations $q_{n+1} = q_{n+1}^{-} = q_{n+1}^{+}$, whereas for
+discontinuous discretisations one typically chooses the average
+$q_{n+1} = \tfrac{1}{2} (q_{n+1}^{-} + q_{n+1}^{+})$.
+
+
+## Continuity Constraints and Numerical Fluxes
+
+The last term in \eqref{eq:hpg-discrete-action} encodes how neighbouring
+subintervals are connected. Different choices reproduce the different types of
+generating functions of classical mechanics:
+
+| Constraint | Continuity of $p$    | Continuity of $q$    |
+|:-----------|:---------------------|:---------------------|
+| $(q,Q)$    | double discontinuous | left-right-continuous|
+| $(q,P)$    | right-continuous     | left-continuous      |
+| $(p,Q)$    | left-continuous      | right-continuous     |
+| $(p,P)$    | left-right-continuous| double discontinuous |
+
+Equivalently, the constraints can be written in terms of a numerical flux
+$\hat{p}_{n+1} \, \hat{q}_{n+1}$ with parameters $\alpha, \beta \in [0,1]$,
+```math
+\begin{aligned}
+\hat{p}_{n+1} &= (1 - \alpha) \, P_{n} (t_{n+1}) + \alpha \, P_{n+1} (t_{n+1}) , &
+\hat{q}_{n+1} &= (1 - \beta) \, Q_{n} (t_{n+1}) + \beta \, Q_{n+1} (t_{n+1}) ,
+\end{aligned}
+```
+which interpolate between the $(q,P)$ constraint ($\alpha = 0$, $\beta = 1$) and
+the $(p,Q)$ constraint ($\alpha = 1$, $\beta = 0$). By varying the polynomial
+degrees, quadrature rule and continuity constraint, this framework recovers many
+established variational integrators and also yields new classes of high-order,
+discontinuous-Galerkin integrators. The finite-difference midpoint and
+trapezoidal Hamilton–Pontryagin integrators implemented in this package (see the
+[Hamilton–Pontryagin page](@ref hpi)) correspond to the lowest-order members of
+this family; Hamilton–Pontryagin integrators on Lie groups are discussed in
+[[BouRabee:2009](@cite)], and the connection to discrete Dirac mechanics in
+[[Leok:2011](@cite)].

--- a/docs/src/integrators/hpi.md
+++ b/docs/src/integrators/hpi.md
@@ -2,7 +2,7 @@
 
 Hamilton-Pontryagin integrators are obtained from discrete versions of the Hamilton-Pontryagin action principle,
 ```math
-\delta \mathcal{A} [q,v,p] = \delta \int_{０}^{T} \left[ L (q, v) - \left< p , \dot{q} - v \right> \right] \, dt = 0 .
+\delta \mathcal{A} [q,v,p] = \delta \int_{0}^{T} \left[ L (q, v) - \left< p , \dot{q} - v \right> \right] \, dt = 0 .
 ```
 
 ## Trapezoidal Discrete Lagrangian

--- a/docs/src/integrators/rk.md
+++ b/docs/src/integrators/rk.md
@@ -202,9 +202,9 @@ in the following way:
 ```math
 \begin{aligned}
 Q_{n,i} &= q_{n} + h \sum \limits_{j=1}^{s} a_{ij} \, v(t_{n} + c_j \Delta t, Q_{n,j}, P_{n,j}) , &
-q_{n+1} &= q_{n} + h \sum \limits_{i=1}^{s} b_{i}  \, v(t_{n} + c_j \Delta t, Q_{n,i}, P_{n,i}) , \\
-P_{n,i} &= p_{n} + h  \sum \limits_{i=1}^{s} \bar{a}_{ij} \, f(t_{n} + c_j \Delta t, Q_{n,j}, P_{n,j}) , &
-p_{n+1} &= p_{n} + h \sum \limits_{i=1}^{s} \bar{b}_{i}   \, f(t_{n} + c_j \Delta t, Q_{n,i}, P_{n,i}) .
+q_{n+1} &= q_{n} + h \sum \limits_{i=1}^{s} b_{i}  \, v(t_{n} + c_i \Delta t, Q_{n,i}, P_{n,i}) , \\
+P_{n,i} &= p_{n} + h  \sum \limits_{j=1}^{s} \bar{a}_{ij} \, f(t_{n} + c_j \Delta t, Q_{n,j}, P_{n,j}) , &
+p_{n+1} &= p_{n} + h \sum \limits_{i=1}^{s} \bar{b}_{i}   \, f(t_{n} + c_i \Delta t, Q_{n,i}, P_{n,i}) .
 \end{aligned}
 ```
 
@@ -244,10 +244,10 @@ Such problems can be integrated with adapted Runge-Kutta methods, namely
 ```math
 \begin{aligned}
 Q_{n,i} &= q_{n} + h \sum \limits_{j=1}^{s} a_{ij} \, v(t_{n} + c_j \Delta t, Q_{n,j}, P_{n,j}) , &
-q_{n+1} &= q_{n} + h \sum \limits_{i=1}^{s} b_{i}  \, v(t_{n} + c_j \Delta t, Q_{n,i}, P_{n,i}) , \\
-P_{n,i} &= p_{n} + h  \sum \limits_{i=1}^{s} \bar{a}_{ij} \, f(t_{n} + c_j \Delta t, Q_{n,j}, P_{n,j}) , &
-p_{n+1} &= p_{n} + h \sum \limits_{i=1}^{s} \bar{b}_{i}   \, f(t_{n} + c_j \Delta t, Q_{n,i}, P_{n,i}) , \\
-P_{n,i} &= ϑ(t_{n} + c_j \Delta t, Q_{n,j}, P_{n,j}) .
+q_{n+1} &= q_{n} + h \sum \limits_{i=1}^{s} b_{i}  \, v(t_{n} + c_i \Delta t, Q_{n,i}, P_{n,i}) , \\
+P_{n,i} &= p_{n} + h  \sum \limits_{j=1}^{s} \bar{a}_{ij} \, f(t_{n} + c_j \Delta t, Q_{n,j}, P_{n,j}) , &
+p_{n+1} &= p_{n} + h \sum \limits_{i=1}^{s} \bar{b}_{i}   \, f(t_{n} + c_i \Delta t, Q_{n,i}, P_{n,i}) , \\
+P_{n,i} &= ϑ(t_{n} + c_i \Delta t, Q_{n,i}, P_{n,i}) .
 \end{aligned}
 ```
 

--- a/docs/src/integrators/rk.md
+++ b/docs/src/integrators/rk.md
@@ -84,7 +84,7 @@ For many methods, tabulated coefficients are included, namely
 | **Diagonally Implicit Methods**                  |        |       |
 | [`CrankNicolson`](@ref)                          | 2      | 2     |
 | [`Crouzeix`](@ref)                               | 2      | 3     |
-| [`KraaijevangerSpijker`](@ref)                   | 2      | 2     |
+| [`KraaijevangerSpijker`](@ref)                   | 2      | 1     |
 | [`QinZhang`](@ref)                               | 2      | 2     |
 | **Fully Implicit Methods**                       |        |       |
 | [`ImplicitEuler`](@ref), [`BackwardEuler`](@ref) | 1      | 1     |

--- a/src/integrators/method_list.jl
+++ b/src/integrators/method_list.jl
@@ -159,6 +159,8 @@ splitting_methods = (
     McLachlan4,
     TripleJump,
     SuzukiFractal,
+    Yoshida6,
+    Yoshida8,
 )
 
 method_groups = (

--- a/src/integrators/splitting/splitting_methods.jl
+++ b/src/integrators/splitting/splitting_methods.jl
@@ -231,7 +231,7 @@ function coefficients(::McLachlan4, ::Type{T}=Float64) where {T}
                                      1 / 5,
                         (-23 - 20*√19) / 270,
                         ( 14 -    √19) / 108])
-    SplittingCoefficientsNonSymmetric(:McLachlanSplitting, 4, a, a[end:-1:1])
+    SplittingCoefficientsNonSymmetric(:McLachlanSplitting, 4, a[end:-1:1], a)
 end
 
 @doc raw"""
@@ -312,4 +312,82 @@ function coefficients(::SuzukiFractal, ::Type{T}=Float64) where {T}
     den = @big 1/(4-fac)
     a = Array{T}([ den, den, -fac*den ])
     SplittingCoefficientsSS(:SuzukiFractalSplitting, 4, a)
+end
+
+
+@doc raw"""
+Yoshida's 6th order symmetric composition method.
+
+The method is the symmetric composition of $m = 7$ symmetric (2nd order) steps,
+```math
+\Phi_{\Delta t} = S_{w_1 \Delta t} \circ S_{w_2 \Delta t} \circ S_{w_3 \Delta t} \circ S_{w_4 \Delta t} \circ S_{w_3 \Delta t} \circ S_{w_2 \Delta t} \circ S_{w_1 \Delta t} ,
+```
+with $w_1 = 0.78451361047755726381949763$, $w_2 = 0.23557321335935813368479318$,
+$w_3 = -1.17767998417887100694641568$, and $w_4 = 1 - 2 (w_1 + w_2 + w_3)$
+(Yoshida's "solution A").
+
+References:
+
+    Haruo Yoshida.
+    Construction of higher order symplectic integrators.
+    Physics Letters A, Volume 150, Pages 262-268, 1990.
+    doi: 10.1016/0375-9601(90)90092-3
+
+    Robert I. McLachlan.
+    On the Numerical Integration of Ordinary Differential Equations by Symmetric Composition Methods
+    SIAM Journal on Scientific Computing, Volume 16, Pages 151-168, 1995.
+    doi: 10.1137/0916010.
+
+"""
+struct Yoshida6 <: AbstractSplittingMethod end
+
+GeometricBase.order(::Union{Yoshida6, Type{Yoshida6}}) = 6
+
+function coefficients(::Yoshida6, ::Type{T}=Float64) where {T}
+    w = parse.(T, ("0.78451361047755726381949763",
+                   "0.23557321335935813368479318",
+                   "-1.17767998417887100694641568"))
+    a = T[w..., 1 - 2 * sum(w)]
+    SplittingCoefficientsSS(:Yoshida6Splitting, 6, a)
+end
+
+
+@doc raw"""
+Yoshida's 8th order symmetric composition method.
+
+The method is the symmetric composition of $m = 15$ symmetric (2nd order) steps
+with weights $w_1, \dotsc, w_8, w_7, \dotsc, w_1$ (Yoshida's "solution D"),
+```math
+w_1 = 0.74167036435061295345 , \quad w_2 = -0.40910082580003159400 , \quad
+w_3 = 0.19075471029623837995 , \quad w_4 = -0.57386247111608226464 ,
+```
+```math
+w_5 = 0.29906418130365592384 , \quad w_6 = 0.33462491824529818378 , \quad
+w_7 = 0.31529309239676659663 , \quad w_8 = 1 - 2 \sum_{i=1}^{7} w_i .
+```
+
+References:
+
+    Haruo Yoshida.
+    Construction of higher order symplectic integrators.
+    Physics Letters A, Volume 150, Pages 262-268, 1990.
+    doi: 10.1016/0375-9601(90)90092-3
+
+    Robert I. McLachlan.
+    On the Numerical Integration of Ordinary Differential Equations by Symmetric Composition Methods
+    SIAM Journal on Scientific Computing, Volume 16, Pages 151-168, 1995.
+    doi: 10.1137/0916010.
+
+"""
+struct Yoshida8 <: AbstractSplittingMethod end
+
+GeometricBase.order(::Union{Yoshida8, Type{Yoshida8}}) = 8
+
+function coefficients(::Yoshida8, ::Type{T}=Float64) where {T}
+    w = parse.(T, ("0.74167036435061295345", "-0.40910082580003159400",
+                   "0.19075471029623837995", "-0.57386247111608226464",
+                   "0.29906418130365592384", "0.33462491824529818378",
+                   "0.31529309239676659663"))
+    a = T[w..., 1 - 2 * sum(w)]
+    SplittingCoefficientsSS(:Yoshida8Splitting, 8, a)
 end

--- a/src/integrators/vi/vprk_methods.jl
+++ b/src/integrators/vi/vprk_methods.jl
@@ -46,7 +46,7 @@ p_{n+1} &= p_{n} + h \sum \limits_{i=1}^{s} \bar{b}_{i} \, F_{n,i} , \\
 satisfying the symplecticity conditions
 ```math
 \begin{aligned}
-b_{i} \bar{a}_{ij} + b_{j} a_{ji} &= b_{i} b_{j} , &
+b_{i} \bar{a}_{ij} + \bar{b}_{j} a_{ji} &= b_{i} \bar{b}_{j} , &
 \bar{b}_i &= b_i .
 \end{aligned}
 ```

--- a/test/integrators/splitting_integrators_tests.jl
+++ b/test/integrators/splitting_integrators_tests.jl
@@ -64,7 +64,7 @@ ssolc = integrate(sode, Composition(McLachlan2()))
 @test relative_maximum_error(ssol, ssolc).q < 1E-15
 
 ssol = integrate(sode, McLachlan4())
-@test relative_maximum_error(ssol, ref).q < 5E-4
+@test relative_maximum_error(ssol, ref).q < 5E-8
 
 ssolc = integrate(sode, Composition(McLachlan4()))
 # @test ssol.q == ssolc.q # TODO: Reactivate!

--- a/test/methods/splitting_methods_tests.jl
+++ b/test/methods/splitting_methods_tests.jl
@@ -17,5 +17,10 @@ using GeometricIntegrators.Integrators: coefficients
 
     @test typeof(coefficients(TripleJump()))    <: SplittingCoefficientsSS{Float64}
     @test typeof(coefficients(SuzukiFractal())) <: SplittingCoefficientsSS{Float64}
+    @test typeof(coefficients(Yoshida6()))      <: SplittingCoefficientsSS{Float64}
+    @test typeof(coefficients(Yoshida8()))      <: SplittingCoefficientsSS{Float64}
+
+    @test order(Yoshida6()) == 6
+    @test order(Yoshida8()) == 8
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,31 @@ end
     include("integrators/ensemble_integrators_tests.jl")
 end
 
+@safetestset "Convergence: Runge-Kutta                                                        " begin
+    include("verification/rk_convergence_tests.jl")
+end
+@safetestset "Convergence: Partitioned Runge-Kutta                                            " begin
+    include("verification/prk_convergence_tests.jl")
+end
+@safetestset "Convergence: Splitting and Composition                                          " begin
+    include("verification/splitting_convergence_tests.jl")
+end
+@safetestset "Convergence: Variational Integrators                                            " begin
+    include("verification/variational_convergence_tests.jl")
+end
+@safetestset "Convergence: Galerkin Variational Integrators                                   " begin
+    include("verification/galerkin_convergence_tests.jl")
+end
+@safetestset "Convergence: Degenerate Variational Integrators                                 " begin
+    include("verification/dvi_convergence_tests.jl")
+end
+@safetestset "Convergence: Hamilton-Pontryagin Integrators                                    " begin
+    include("verification/hpi_convergence_tests.jl")
+end
+@safetestset "Convergence: Projected Integrators                                              " begin
+    include("verification/projection_convergence_tests.jl")
+end
+
 @safetestset "Method Tests                                                                    " begin
     include("methods/methods_tests.jl")
 end

--- a/test/verification/dvi_convergence_tests.jl
+++ b/test/verification/dvi_convergence_tests.jl
@@ -1,0 +1,51 @@
+using GeometricIntegrators
+import GeometricProblems.Pendulum as Pendulum
+using GeometricProblems.LotkaVolterra2d
+using Test
+
+include("verification_utilities.jl")
+
+const T = 1.0
+steps(n0, k) = T ./ (n0 .* 2 .^ (0:k))
+emq(sol, ref) = relative_maximum_error(sol.q, ref.q)
+
+@testset "Degenerate variational integrator convergence" begin
+
+    # DVRK on the (regular) pendulum IODE reaches the full order 2s of its
+    # underlying Gauss-Legendre tableau.
+    @testset "DVRK order (regular Lagrangian)" begin
+        vbuild(Δt) = Pendulum.iodeproblem(; timespan = (0.0, T), timestep = Δt)
+        vref(prob) = integrate(prob, VPRKGauss(8))
+        test_convergence_order(vbuild, DVRK(Gauss(2)), steps(4, 3); reference = vref, errormetric = emq, expected = 4, label = "DVRK(Gauss(2))")
+        test_convergence_order(vbuild, DVRK(Gauss(3)), steps(2, 3); reference = vref, errormetric = emq, expected = 6, label = "DVRK(Gauss(3))")
+    end
+
+    # On the degenerate Lotka-Volterra Lagrangian, DVRK exhibits order reduction:
+    # DVRK(Gauss(s)) converges at order s rather than 2s (a known feature of
+    # symplectic RK methods on degenerate Lagrangians; see VERIFICATION_REPORT.md).
+    @testset "DVRK order reduction (degenerate Lagrangian)" begin
+        q₀ = [1.0, 1.0]
+        params = (a₁ = 1.0, a₂ = 1.0, b₁ = -1.0, b₂ = -2.0)
+        lvbuild(Δt) = lodeproblem(q₀; timespan = (0.0, T), timestep = Δt, parameters = params)
+        lvref(prob) = integrate(odeproblem(q₀; timespan = timespan(prob), timestep = timestep(prob), parameters = params), Gauss(8))
+        test_convergence_order(lvbuild, DVRK(Gauss(1)), steps(20, 4); reference = lvref, errormetric = emq, expected = 1, label = "DVRK(Gauss(1))/LV")
+        test_convergence_order(lvbuild, DVRK(Gauss(2)), steps(10, 4); reference = lvref, errormetric = emq, expected = 2, plateau = 1e-11, label = "DVRK(Gauss(2))/LV")
+    end
+
+    # Fixed-step accuracy regression for the low-order degenerate variational
+    # integrators (matching the established Lotka-Volterra test). NOTE: over long
+    # integration times these methods do not converge cleanly to the ODE reference;
+    # see VERIFICATION_REPORT.md. Here we only assert the short-time accuracy that
+    # the package already relies on.
+    @testset "Low-order DVI accuracy (fixed step)" begin
+        q₀ = [1.0, 1.0]
+        params = (a₁ = 1.0, a₂ = 1.0, b₁ = -1.0, b₂ = -2.0)
+        tspan = (0.0, 0.1)
+        lode = lodeproblem(q₀; timespan = tspan, timestep = 0.01, parameters = params)
+        ref = integrate(odeproblem(q₀; timespan = tspan, timestep = 0.01, parameters = params), Gauss(8))
+        @test relative_maximum_error(integrate(lode, DVIA()).q, ref.q) < 1e-1
+        @test relative_maximum_error(integrate(lode, DVIB()).q, ref.q) < 1e-1
+        @test relative_maximum_error(integrate(lode, CMDVI()).q, ref.q) < 4e-3
+        @test relative_maximum_error(integrate(lode, CTDVI()).q, ref.q) < 4e-3
+    end
+end

--- a/test/verification/galerkin_convergence_tests.jl
+++ b/test/verification/galerkin_convergence_tests.jl
@@ -1,0 +1,24 @@
+using GeometricIntegrators
+using GeometricProblems.HarmonicOscillator
+using QuadratureRules
+using CompactBasisFunctions
+using Test
+
+include("verification_utilities.jl")
+
+# Continuous Galerkin variational integrators with Gauss-Legendre quadrature and
+# a Lagrange basis, on the harmonic oscillator IODE (analytic PODE reference).
+# With s Gauss points the position converges at order 2s-2.
+const T = 1.0
+build(Δt) = iodeproblem(; timespan = (0.0, T), timestep = Δt)
+pref(prob) = exact_solution(podeproblem(; timespan = timespan(prob), timestep = timestep(prob)))
+steps(n0, k) = T ./ (n0 .* 2 .^ (0:k))
+emq(sol, ref) = relative_maximum_error(sol.q, ref.q)
+
+cgvi(s) = (Q = GaussLegendreQuadrature(s); CGVI(Lagrange(QuadratureRules.nodes(Q)), Q))
+
+@testset "Continuous Galerkin variational integrator convergence" begin
+    test_convergence_order(build, cgvi(2), steps(2, 4); reference = pref, errormetric = emq, expected = 2, label = "CGVI(Gauss(2))")
+    test_convergence_order(build, cgvi(3), steps(2, 3); reference = pref, errormetric = emq, expected = 4, label = "CGVI(Gauss(3))")
+    test_convergence_order(build, cgvi(4), steps(2, 3); reference = pref, errormetric = emq, expected = 6, label = "CGVI(Gauss(4))")
+end

--- a/test/verification/hpi_convergence_tests.jl
+++ b/test/verification/hpi_convergence_tests.jl
@@ -1,0 +1,35 @@
+using GeometricIntegrators
+using GeometricProblems.HarmonicOscillator
+using Test
+
+include("verification_utilities.jl")
+
+const T = 1.0
+build(Δt) = lodeproblem(; timespan = (0.0, T), timestep = Δt)
+pref(prob) = exact_solution(podeproblem(; timespan = timespan(prob), timestep = timestep(prob)))
+steps(n0, k) = T ./ (n0 .* 2 .^ (0:k))
+emq(sol, ref) = relative_maximum_error(sol.q, ref.q)
+
+# Trivial velocity map φ_h(q̄, q) = (q - q̄)/Δt and its derivatives, matching the
+# existing Hamilton-Pontryagin integrator tests.
+ϕ(v, q̄, q, a, Δt) = (v .= (q .- q̄) ./ Δt)
+function D₁ϕ(d, q̄, q, a, Δt)
+    d .= 0
+    for i in eachindex(q)
+        d[i, i] = -1 / Δt
+    end
+end
+function D₂ϕ(d, q̄, q, a, Δt)
+    d .= 0
+    for i in eachindex(q)
+        d[i, i] = +1 / Δt
+    end
+end
+Dₐϕ(d, q̄, q, a, Δt) = (d .= 0)
+
+@testset "Hamilton-Pontryagin convergence" begin
+    test_convergence_order(build, HPImidpoint(ϕ, D₁ϕ, D₂ϕ, Dₐϕ, Float64[]), steps(10, 4);
+        reference = pref, errormetric = emq, expected = 2, label = "HPImidpoint")
+    test_convergence_order(build, HPItrapezoidal(ϕ, D₁ϕ, D₂ϕ, Dₐϕ, Float64[]), steps(10, 4);
+        reference = pref, errormetric = emq, expected = 2, label = "HPItrapezoidal")
+end

--- a/test/verification/prk_convergence_tests.jl
+++ b/test/verification/prk_convergence_tests.jl
@@ -1,0 +1,31 @@
+using GeometricIntegrators
+import GeometricProblems.Pendulum as Pendulum
+using Test
+
+include("verification_utilities.jl")
+
+# Nonlinear pendulum PODE with a high-order reference, so that the measured order
+# is the true (nonlinear) order rather than a linear super-convergence artifact.
+const T = 1.0
+build(Δt) = Pendulum.podeproblem(; timespan = (0.0, T), timestep = Δt)
+href(prob) = integrate(prob, PartitionedGauss(8))
+steps(n0, k) = T ./ (n0 .* 2 .^ (0:k))
+emq(sol, ref) = relative_maximum_error(sol.q, ref.q)
+
+@testset "Partitioned Runge-Kutta convergence" begin
+    test_convergence_order(build, SymplecticEulerA(), steps(20, 4); reference = href, errormetric = emq, expected = 1, label = "SymplecticEulerA")
+    test_convergence_order(build, SymplecticEulerB(), steps(20, 4); reference = href, errormetric = emq, expected = 1, label = "SymplecticEulerB")
+    test_convergence_order(build, PartitionedGauss(2), steps(5, 4); reference = href, errormetric = emq, expected = 4, label = "PartitionedGauss(2)")
+    test_convergence_order(build, LobattoIIIAIIIB(2), steps(5, 4); reference = href, errormetric = emq, expected = 2, label = "LobattoIIIAIIIB(2)")
+    test_convergence_order(build, LobattoIIIBIIIA(2), steps(5, 4); reference = href, errormetric = emq, expected = 2, label = "LobattoIIIBIIIA(2)")
+    test_convergence_order(build, LobattoIIIAIIIB(3), steps(5, 3); reference = href, errormetric = emq, expected = 4, label = "LobattoIIIAIIIB(3)")
+
+    # Known order deficiencies (see VERIFICATION_REPORT.md): the "order 2s" Lobatto
+    # IIIF/IIIG pairs only reach order 2s-2 = 2 for s = 2.
+    @testset "Known order deficiencies (broken)" begin
+        r = estimate_convergence_order(build, LobattoIIIFIIIF̄(2), steps(5, 4); reference = href, errormetric = emq)
+        @test_broken isapprox(r.order, 4; atol = 0.4)
+        r = estimate_convergence_order(build, LobattoIIIGIIIḠ(2), steps(5, 4); reference = href, errormetric = emq)
+        @test_broken isapprox(r.order, 4; atol = 0.4)
+    end
+end

--- a/test/verification/projection_convergence_tests.jl
+++ b/test/verification/projection_convergence_tests.jl
@@ -1,0 +1,36 @@
+using GeometricIntegrators
+using GeometricProblems.HarmonicOscillator
+using Test
+
+include("verification_utilities.jl")
+
+# Projected Runge-Kutta integrators on the harmonic oscillator DAE, referenced
+# against the analytic ODE solution. Projected Gauss(s) converges at order 2s and
+# preserves the Hamiltonian to machine precision.
+const T = 1.0
+build(Δt) = daeproblem(; timespan = (0.0, T), timestep = Δt)
+ref(prob) = exact_solution(odeproblem(; timespan = timespan(prob), timestep = timestep(prob)))
+steps(n0, k) = T ./ (n0 .* 2 .^ (0:k))
+emq(sol, r) = relative_maximum_error(sol.q, r.q)
+
+energy_change(sol, params) = abs(hamiltonian(sol[end].t, sol[end].q, params) -
+                                 hamiltonian(sol[begin].t, sol[begin].q, params))
+
+@testset "Projected integrator convergence and energy conservation" begin
+    for (P, name, etol) in ((PostProjection, "PostProjection", 1),
+                            (MidpointProjection, "MidpointProjection", 2),
+                            (SymmetricProjection, "SymmetricProjection", 2))
+        @testset "$name" begin
+            test_convergence_order(build, P(Gauss(1)), steps(10, 4); reference = ref, errormetric = emq, expected = 2, label = "$name(Gauss(1))")
+            test_convergence_order(build, P(Gauss(2)), steps(5, 4);  reference = ref, errormetric = emq, expected = 4, label = "$name(Gauss(2))")
+            test_convergence_order(build, P(Gauss(3)), steps(3, 3);  reference = ref, errormetric = emq, expected = 6, label = "$name(Gauss(3))")
+
+            # Energy conservation over the trajectory (to machine precision).
+            prob = build(0.1)
+            for s in 1:3
+                sol = integrate(prob, P(Gauss(s)))
+                @test energy_change(sol, parameters(prob)) < etol * eps()
+            end
+        end
+    end
+end

--- a/test/verification/rk_convergence_tests.jl
+++ b/test/verification/rk_convergence_tests.jl
@@ -37,6 +37,9 @@ steps(n0, k) = T ./ (n0 .* 2 .^ (0:k))
         test_convergence_order(build, CrankNicolson(), steps(10, 5); reference = exact_solution, expected = 2, label = "CrankNicolson")
         test_convergence_order(build, Crouzeix(),      steps(10, 5); reference = exact_solution, expected = 3, label = "Crouzeix")
         test_convergence_order(build, QinZhang(),      steps(10, 5); reference = exact_solution, expected = 2, label = "QinZhang")
+        # KraaijevangerSpijker is a first-order method (its order attribute was
+        # corrected to 1 in RungeKutta.jl v0.5.22).
+        test_convergence_order(build, KraaijevangerSpijker(), steps(10, 5); reference = exact_solution, expected = 1, label = "KraaijevangerSpijker")
     end
 
     @testset "Fully implicit Runge-Kutta" begin
@@ -59,16 +62,12 @@ steps(n0, k) = T ./ (n0 .* 2 .^ (0:k))
         test_convergence_order(build, LobattoIIIB(3), steps(6, 4); reference = exact_solution, expected = 4, label = "LobattoIIIB(3)")
     end
 
-    # Known order deficiencies (see VERIFICATION_REPORT.md). These methods do not
-    # reach their documented order when applied as standalone ODE integrators;
-    # the root cause is in the tableau coefficients (RungeKutta.jl). Recorded as
-    # broken so a future fix is detected automatically.
+    # Known order deficiency (see VERIFICATION_REPORT.md): LobattoIIIB has a
+    # singular coefficient matrix, so as a standalone ODE integrator its stage
+    # system is degenerate and it drops to order 1 (it is intended for use in
+    # symplectic partitioned pairs / as a VPRK component). Recorded as broken so
+    # a future change is detected automatically.
     @testset "Known order deficiencies (broken)" begin
-        # KraaijevangerSpijker: coefficients satisfy only the order-1 conditions
-        # (Σᵢbᵢcᵢ = 2 ≠ 1/2), yet order(·) and the docs claim order 2.
-        r = estimate_convergence_order(build, KraaijevangerSpijker(), steps(10, 5); reference = exact_solution)
-        @test_broken isapprox(r.order, 2; atol = 0.35)
-        # LobattoIIIB(2): singular A ⇒ degenerate stage system ⇒ order 1 standalone.
         r = estimate_convergence_order(build, LobattoIIIB(2), steps(10, 4); reference = exact_solution)
         @test_broken isapprox(r.order, 2; atol = 0.35)
     end

--- a/test/verification/rk_convergence_tests.jl
+++ b/test/verification/rk_convergence_tests.jl
@@ -1,0 +1,76 @@
+using GeometricIntegrators
+using GeometricProblems.HarmonicOscillator
+using Test
+
+include("verification_utilities.jl")
+
+# The harmonic oscillator has an analytic solution, so we can measure the true
+# error directly. It is a *linear* problem, so some methods super-converge on it;
+# the assertions below therefore only require the empirical order to match the
+# documented order (super-convergence beyond that is not flagged).
+const T = 1.0
+build(Δt) = odeproblem(; timespan = (0.0, T), timestep = Δt)
+
+# Refinement levels: coarser base steps for higher-order methods so that the
+# coarsest error stays above the roundoff plateau (the plateau filter in
+# `estimate_convergence_order` discards the saturated tail).
+steps(n0, k) = T ./ (n0 .* 2 .^ (0:k))
+
+@testset "Runge-Kutta convergence" begin
+
+    @testset "Explicit Runge-Kutta" begin
+        test_convergence_order(build, ExplicitEulerRK(), steps(10, 5); reference = exact_solution, expected = 1, label = "ExplicitEulerRK")
+        test_convergence_order(build, ExplicitMidpoint(), steps(10, 5); reference = exact_solution, expected = 2, label = "ExplicitMidpoint")
+        test_convergence_order(build, Heun2(),  steps(10, 5); reference = exact_solution, expected = 2, label = "Heun2")
+        test_convergence_order(build, Heun3(),  steps(10, 5); reference = exact_solution, expected = 3, label = "Heun3")
+        test_convergence_order(build, Kutta3(), steps(10, 5); reference = exact_solution, expected = 3, label = "Kutta3")
+        test_convergence_order(build, Ralston2(), steps(10, 5); reference = exact_solution, expected = 2, label = "Ralston2")
+        test_convergence_order(build, Ralston3(), steps(10, 5); reference = exact_solution, expected = 3, label = "Ralston3")
+        test_convergence_order(build, Runge2(), steps(10, 5); reference = exact_solution, expected = 2, label = "Runge2")
+        test_convergence_order(build, SSPRK2(), steps(10, 5); reference = exact_solution, expected = 2, label = "SSPRK2")
+        test_convergence_order(build, SSPRK3(), steps(10, 5); reference = exact_solution, expected = 3, label = "SSPRK3")
+        test_convergence_order(build, RK4(),   steps(10, 4); reference = exact_solution, expected = 4, label = "RK4")
+        test_convergence_order(build, RK438(), steps(10, 4); reference = exact_solution, expected = 4, label = "RK438")
+    end
+
+    @testset "Diagonally implicit Runge-Kutta" begin
+        test_convergence_order(build, CrankNicolson(), steps(10, 5); reference = exact_solution, expected = 2, label = "CrankNicolson")
+        test_convergence_order(build, Crouzeix(),      steps(10, 5); reference = exact_solution, expected = 3, label = "Crouzeix")
+        test_convergence_order(build, QinZhang(),      steps(10, 5); reference = exact_solution, expected = 2, label = "QinZhang")
+    end
+
+    @testset "Fully implicit Runge-Kutta" begin
+        test_convergence_order(build, ImplicitEulerRK(), steps(10, 5); reference = exact_solution, expected = 1, label = "ImplicitEulerRK")
+        test_convergence_order(build, ImplicitMidpoint(), steps(10, 5); reference = exact_solution, expected = 2, label = "ImplicitMidpoint")
+        test_convergence_order(build, SRK3(), steps(4, 4); reference = exact_solution, expected = 4, label = "SRK3")
+        test_convergence_order(build, Gauss(1), steps(10, 4); reference = exact_solution, expected = 2, label = "Gauss(1)")
+        test_convergence_order(build, Gauss(2), steps(4, 4);  reference = exact_solution, expected = 4, label = "Gauss(2)")
+        test_convergence_order(build, Gauss(3), steps(2, 4);  reference = exact_solution, expected = 6, label = "Gauss(3)")
+    end
+
+    @testset "Radau and Lobatto" begin
+        test_convergence_order(build, RadauIA(2),  steps(6, 4); reference = exact_solution, expected = 3, label = "RadauIA(2)")
+        test_convergence_order(build, RadauIIA(2), steps(6, 4); reference = exact_solution, expected = 3, label = "RadauIIA(2)")
+        test_convergence_order(build, LobattoIIIA(2), steps(10, 4); reference = exact_solution, expected = 2, label = "LobattoIIIA(2)")
+        test_convergence_order(build, LobattoIIIC(2), steps(10, 4); reference = exact_solution, expected = 2, label = "LobattoIIIC(2)")
+        test_convergence_order(build, LobattoIIID(2), steps(10, 4); reference = exact_solution, expected = 2, label = "LobattoIIID(2)")
+        test_convergence_order(build, LobattoIIIE(2), steps(10, 4); reference = exact_solution, expected = 2, label = "LobattoIIIE(2)")
+        test_convergence_order(build, LobattoIIIA(3), steps(6, 4); reference = exact_solution, expected = 4, label = "LobattoIIIA(3)")
+        test_convergence_order(build, LobattoIIIB(3), steps(6, 4); reference = exact_solution, expected = 4, label = "LobattoIIIB(3)")
+    end
+
+    # Known order deficiencies (see VERIFICATION_REPORT.md). These methods do not
+    # reach their documented order when applied as standalone ODE integrators;
+    # the root cause is in the tableau coefficients (RungeKutta.jl). Recorded as
+    # broken so a future fix is detected automatically.
+    @testset "Known order deficiencies (broken)" begin
+        # KraaijevangerSpijker: coefficients satisfy only the order-1 conditions
+        # (Σᵢbᵢcᵢ = 2 ≠ 1/2), yet order(·) and the docs claim order 2.
+        r = estimate_convergence_order(build, KraaijevangerSpijker(), steps(10, 5); reference = exact_solution)
+        @test_broken isapprox(r.order, 2; atol = 0.35)
+        # LobattoIIIB(2): singular A ⇒ degenerate stage system ⇒ order 1 standalone.
+        r = estimate_convergence_order(build, LobattoIIIB(2), steps(10, 4); reference = exact_solution)
+        @test_broken isapprox(r.order, 2; atol = 0.35)
+    end
+
+end

--- a/test/verification/splitting_convergence_tests.jl
+++ b/test/verification/splitting_convergence_tests.jl
@@ -1,0 +1,32 @@
+using GeometricIntegrators
+using GeometricProblems.HarmonicOscillator
+using Test
+
+include("verification_utilities.jl")
+
+# Splitting/composition methods are tested on the harmonic oscillator SODE; the
+# reference is the analytic solution of the corresponding ODE.
+const T = 1.0
+build(Δt) = sodeproblem(; timespan = (0.0, T), timestep = Δt)
+sref(prob) = exact_solution(odeproblem(; timespan = timespan(prob), timestep = timestep(prob)))
+steps(n0, k) = T ./ (n0 .* 2 .^ (0:k))
+emq(sol, ref) = relative_maximum_error(sol.q, ref.q)
+
+@testset "Splitting and composition convergence" begin
+    test_convergence_order(build, LieA(),   steps(10, 4); reference = sref, errormetric = emq, expected = 1, label = "LieA")
+    test_convergence_order(build, LieB(),   steps(10, 4); reference = sref, errormetric = emq, expected = 1, label = "LieB")
+    test_convergence_order(build, Strang(), steps(10, 4); reference = sref, errormetric = emq, expected = 2, label = "Strang")
+    test_convergence_order(build, McLachlan2(), steps(10, 4); reference = sref, errormetric = emq, expected = 2, label = "McLachlan2")
+    test_convergence_order(build, McLachlan4(), steps(10, 4); reference = sref, errormetric = emq, expected = 4, label = "McLachlan4")
+    test_convergence_order(build, TripleJump(), steps(10, 4); reference = sref, errormetric = emq, expected = 4, label = "TripleJump")
+    test_convergence_order(build, SuzukiFractal(), steps(10, 4); reference = sref, errormetric = emq, expected = 4, label = "SuzukiFractal")
+
+    # Higher-order Yoshida composition methods (reach the roundoff plateau quickly,
+    # so use coarser step ranges / a longer interval).
+    test_convergence_order(build, Yoshida6(), steps(4, 4); reference = sref, errormetric = emq, expected = 6, label = "Yoshida6")
+    let T2 = 2.0
+        build2(Δt) = sodeproblem(; timespan = (0.0, T2), timestep = Δt)
+        sref2(prob) = exact_solution(odeproblem(; timespan = timespan(prob), timestep = timestep(prob)))
+        test_convergence_order(build2, Yoshida8(), T2 ./ (2 .* 2 .^ (0:5)); reference = sref2, errormetric = emq, expected = 8, label = "Yoshida8")
+    end
+end

--- a/test/verification/variational_convergence_tests.jl
+++ b/test/verification/variational_convergence_tests.jl
@@ -1,0 +1,50 @@
+using GeometricIntegrators
+using GeometricProblems.HarmonicOscillator
+import GeometricProblems.Pendulum as Pendulum
+using Test
+
+include("verification_utilities.jl")
+
+const T = 1.0
+steps(n0, k) = T ./ (n0 .* 2 .^ (0:k))
+emq(sol, ref) = relative_maximum_error(sol.q, ref.q)
+
+# Position-momentum and discrete-Euler-Lagrange integrators on the harmonic
+# oscillator LODE, referenced against the analytic PODE solution.
+lbuild(Δt) = lodeproblem(; timespan = (0.0, T), timestep = Δt)
+pref(prob) = exact_solution(podeproblem(; timespan = timespan(prob), timestep = timestep(prob)))
+delbuild_m(Δt) = DELEProblem(lodeproblem(; timespan = (0.0, T), timestep = Δt), Midpoint())
+delbuild_t(Δt) = DELEProblem(lodeproblem(; timespan = (0.0, T), timestep = Δt), Trapezoidal())
+
+# VPRK integrators on the nonlinear pendulum IODE (true nonlinear order).
+vbuild(Δt) = Pendulum.iodeproblem(; timespan = (0.0, T), timestep = Δt)
+vref(prob) = integrate(prob, VPRKGauss(8))
+
+@testset "Variational integrator convergence" begin
+    @testset "Position-momentum and discrete Euler-Lagrange" begin
+        test_convergence_order(lbuild, PMVImidpoint(),    steps(10, 4); reference = pref, errormetric = emq, expected = 2, label = "PMVImidpoint")
+        test_convergence_order(lbuild, PMVItrapezoidal(), steps(10, 4); reference = pref, errormetric = emq, expected = 2, label = "PMVItrapezoidal")
+        test_convergence_order(delbuild_m, DiscreteEulerLagrange(), steps(10, 4); reference = pref, errormetric = emq, expected = 2, label = "DEL-midpoint")
+        test_convergence_order(delbuild_t, DiscreteEulerLagrange(), steps(10, 4); reference = pref, errormetric = emq, expected = 2, label = "DEL-trapezoidal")
+    end
+
+    @testset "VPRK" begin
+        test_convergence_order(vbuild, VPRKGauss(2), steps(5, 4); reference = vref, errormetric = emq, expected = 4, label = "VPRKGauss(2)")
+        test_convergence_order(vbuild, VPRKGauss(3), steps(3, 3); reference = vref, errormetric = emq, expected = 6, label = "VPRKGauss(3)")
+        test_convergence_order(vbuild, VPRKLobattoIIIAIIIB(2), steps(5, 4); reference = vref, errormetric = emq, expected = 2, label = "VPRKLobattoIIIAIIIB(2)")
+
+        # Known order deficiencies (see VERIFICATION_REPORT.md): several higher-order
+        # Lobatto VPRK methods do not reach their documented order. The "order 2s"
+        # IIIF/IIIG methods only reach order 2 for s = 2, and VPRKLobattoIIIAIIIB(3)
+        # reaches order 2 rather than 2s-2 = 4 (whereas the plain partitioned
+        # LobattoIIIAIIIB(3) does reach order 4).
+        @testset "Known order deficiencies (broken)" begin
+            r = estimate_convergence_order(vbuild, VPRKLobattoIIIF̄(2), steps(5, 4); reference = vref, errormetric = emq)
+            @test_broken isapprox(r.order, 4; atol = 0.4)
+            r = estimate_convergence_order(vbuild, VPRKLobattoIIIG(2), steps(5, 4); reference = vref, errormetric = emq)
+            @test_broken isapprox(r.order, 4; atol = 0.4)
+            r = estimate_convergence_order(vbuild, VPRKLobattoIIIAIIIB(3), steps(3, 4); reference = vref, errormetric = emq)
+            @test_broken isapprox(r.order, 4; atol = 0.4)
+        end
+    end
+end

--- a/test/verification/verification_utilities.jl
+++ b/test/verification/verification_utilities.jl
@@ -1,0 +1,138 @@
+# Shared utilities for the numerical-verification test suite.
+#
+# These are plain functions (no `@testset`), meant to be `include`d inside each
+# per-family `@safetestset` module. They empirically verify that an integrator
+# achieves its documented convergence order and, for geometric integrators, that
+# it preserves energy/invariants over long integration times.
+
+using GeometricIntegrators
+using Test
+
+"""
+    loglog_slope(dts, errs)
+
+Least-squares slope of `log(errs)` versus `log(dts)`, i.e. the empirical
+convergence order of an error sequence obtained at the timesteps `dts`.
+"""
+function loglog_slope(dts::AbstractVector, errs::AbstractVector)
+    @assert length(dts) == length(errs)
+    x = log.(dts)
+    y = log.(errs)
+    n = length(x)
+    x̄ = sum(x) / n
+    ȳ = sum(y) / n
+    return sum((x .- x̄) .* (y .- ȳ)) / sum((x .- x̄) .^ 2)
+end
+
+"""
+    linear_slope(xs, ys)
+
+Ordinary (non-log) least-squares slope of `ys` versus `xs`. Used as a drift
+diagnostic for the per-interval energy error.
+"""
+function linear_slope(xs::AbstractVector, ys::AbstractVector)
+    @assert length(xs) == length(ys)
+    n = length(xs)
+    x̄ = sum(xs) / n
+    ȳ = sum(ys) / n
+    d = sum((xs .- x̄) .^ 2)
+    return d == 0 ? zero(ȳ) : sum((xs .- x̄) .* (ys .- ȳ)) / d
+end
+
+# Default error metric: relative maximum error in the position component `q`.
+default_errormetric(sol, ref) = relative_maximum_error(sol, ref).q
+
+"""
+    estimate_convergence_order(problem_builder, method, timesteps;
+                               reference, errormetric, plateau)
+
+Integrate `method` at each `Δt` in `timesteps` (building the problem via
+`problem_builder(Δt)`), measure the error against `reference(prob)` with
+`errormetric(sol, ref)`, and return a NamedTuple `(order, dts, errs, mask)` where
+`order` is the log-log slope over the points that lie above the roundoff plateau.
+
+* `problem_builder :: Δt -> problem`
+* `reference       :: problem -> solution`   (e.g. `exact_solution` or a high-order run)
+* `errormetric     :: (sol, ref) -> Real`
+* `plateau`        : points with `err ≤ plateau`, or non-decreasing errors, are discarded
+"""
+function estimate_convergence_order(problem_builder, method, timesteps;
+        reference,
+        errormetric = default_errormetric,
+        plateau = 1e-13)
+    dts = collect(float.(timesteps))
+    errs = map(dts) do Δt
+        prob = problem_builder(Δt)
+        errormetric(integrate(prob, method), reference(prob))
+    end
+    # Keep points above the roundoff floor that are still strictly decreasing;
+    # this drops the flattened tail where high-order methods hit machine precision.
+    mask = trues(length(errs))
+    for i in eachindex(errs)
+        mask[i] = errs[i] > plateau && (i == 1 || errs[i] < errs[i-1])
+    end
+    ord = count(mask) >= 2 ? loglog_slope(dts[mask], errs[mask]) : NaN
+    return (order = ord, dts = dts, errs = errs, mask = mask)
+end
+
+"""
+    test_convergence_order(problem_builder, method, timesteps; kwargs...)
+
+Assert that the empirical convergence order of `method` matches `expected`
+(default `order(method)`) within `atol`, using at least `minpoints` valid points.
+Returns the result NamedTuple from [`estimate_convergence_order`](@ref).
+"""
+function test_convergence_order(problem_builder, method, timesteps;
+        reference,
+        errormetric = default_errormetric,
+        expected = order(method),
+        atol = 0.35,
+        plateau = 1e-13,
+        minpoints = 3,
+        label = string(nameof(typeof(method))))
+    @assert expected isa Number "pass an explicit `expected` order for $(label)"
+    res = estimate_convergence_order(problem_builder, method, timesteps;
+        reference, errormetric, plateau)
+    @testset "$(label): order ≈ $(expected)" begin
+        @test count(res.mask) >= minpoints
+        @test isapprox(res.order, expected; atol = atol)
+    end
+    return res
+end
+
+"""
+    energy_error(sol, hamiltonian, params; partitioned)
+
+Relative energy error time series `(H(t) - H(0)) / H(0)` computed with the
+problem's `hamiltonian`. Uses the partitioned `(t, q, p, params)` signature when
+`partitioned` is true, otherwise the `(t, q, params)` signature.
+"""
+function energy_error(sol, hamiltonian, params; partitioned::Bool)
+    _, errds = partitioned ?
+        compute_invariant_error(sol.t, sol.q, sol.p, params, hamiltonian) :
+        compute_invariant_error(sol.t, sol.q, params, hamiltonian)
+    return errds
+end
+
+"""
+    test_energy_behaviour(prob, method; hamiltonian, partitioned,
+                          interval_length, energy_tol, drift_tol, label)
+
+Integrate a long trajectory and assert (a) the relative energy error stays
+bounded by `energy_tol`, and (b) the per-interval maximum energy error exhibits
+no secular growth (linear drift slope below `drift_tol`). `nt` (from `prob`) must
+be divisible by `interval_length`.
+"""
+function test_energy_behaviour(prob, method; hamiltonian, partitioned::Bool,
+        interval_length = 100, energy_tol, drift_tol,
+        label = string(nameof(typeof(method))))
+    sol = integrate(prob, method)
+    params = parameters(prob)
+    errds = energy_error(sol, hamiltonian, params; partitioned)
+    tdrift, idrift = compute_error_drift(sol.t, errds, interval_length)
+    @testset "$(label): energy behaviour" begin
+        @test maximum(abs.(errds.d)) < energy_tol
+        @test abs(linear_slope(collect(tdrift.d), collect(idrift.d))) < drift_tol
+    end
+    return (errds = errds, tdrift = tdrift, idrift = idrift)
+end


### PR DESCRIPTION
Audit of all non-SPARK integrators for correctness and consistency with the docstrings, documentation, and geometric-numerical-integration literature. Adds a numerical convergence-verification test suite, fixes a confirmed order bug, and extends the splitting methods to 6th/8th order.

## Fixes
- **McLachlan4 composition ordering.** The method converged at order 2 instead of 4. The √19 coefficients are correct (verified to match McLachlan 1995, Table 2, order-4 type-S m=5, via the eq. (2.6) determining equations), but each stage composed the forward flow `φ` before its adjoint `φ*`; eq. (1.8) requires the adjoint first. Fixed by swapping the `a`/`b` vectors in the `SplittingCoefficientsNonSymmetric` constructor. Now converges at order 4; the existing accuracy tolerance is tightened `5E-4 → 5E-8`.
- **VPRK docstring**: symplecticity condition corrected to the general barred form `bᵢāᵢⱼ + b̄ⱼaⱼᵢ = bᵢb̄ⱼ`, consistent with IRK/IPRK/`rk.md`/`vprk.md`.
- **`rk.md`**: fixed stage-time (`c_j`→`c_i`) and summation-index (`∑ᵢ`→`∑ⱼ`) typos in the partitioned and implicit-equation blocks.
- **`hpi.md`**: replaced a full-width digit `０` with `0` in the action-integral bound.

## New methods
- **`Yoshida6`** (6th order, symmetric composition, m=7 — Yoshida's "solution A") and **`Yoshida8`** (8th order, m=15 — "solution D"), from Yoshida 1990 / McLachlan 1995 Table 2. Coefficients verified to high precision (BigFloat matrix-exponential order check).

## New documentation
- `dvi.md` (degenerate variational integrators: DVIA/DVIB/CMDVI/CTDVI + DVRK) and `hpg.md` (Hamilton–Pontryagin–Galerkin framework), in the CGVI/VPRK style, plus supporting bibliography entries. `hpg.md` re-enabled in `make.jl`.

## New tests
- `test/verification/`: a reusable convergence/energy harness and per-family convergence tests (rk, prk, splitting, variational, galerkin, dvi, hpi, projection), wired into `runtests.jl`. Confirmed order deficiencies that originate in RungeKutta.jl coefficients are recorded as `@test_broken` at the documented order (e.g. `KraaijevangerSpijker` order 1 vs 2 — fixed upstream in RungeKutta.jl v0.5.22, pending release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)