### PR TITLE
Verify SPARK submodule; fix HSPARK-secondary bugs; add convergence suite

### DIFF
--- a/VERIFICATION_REPORT.md
+++ b/VERIFICATION_REPORT.md
@@ -460,3 +460,108 @@ suppresses only the solver-cap warning). These calls are therefore wrapped in a
 that one integration. `muffle` changes only logging, so the measured errors and
 the `@test_broken` status are unaffected. The suite now runs warning-free with the
 same 133 pass / 45 broken tally.
+
+---
+
+# Fourth pass — SPARK submodule (`src/spark/`)
+
+The first three passes covered the whole package **except** the SPARK submodule.
+This pass completes the verification: a static + dynamic check of every SPARK
+integrator family (`SPARK`, `VPARK`, `HPARK`, `VSPARK`/`primary`/`secondary`,
+`HSPARK`/`primary`/`secondary`, `SLRK`) and a root-cause diagnosis of why several
+SPARK methods do not converge.
+
+## Method and reference basis
+
+SPARK methods are largely **original** and not documented in the standard
+geometric-numerical-integration literature. Verification used the two draft
+manuscripts *SPARK Methods for Degenerate Lagrangian Systems* and *SPARK Methods
+for Hamiltonian Systems Subject to Dirac Constraints*. Those manuscripts are
+**unfinished**: they prove the *symplecticity* conditions but defer all
+order/convergence analysis to Jay's cited papers ("order and convergence will be
+discussed elsewhere"). Concrete order numbers therefore come from the code's
+tableau `o` fields (Gauß `2s`, Lobatto-pair `2s−2`, SLRK-Lobatto `2s−2`) and from
+empirical measurement. The manuscripts do, however, make three qualitative
+predictions that explain almost all of the observed non-convergence:
+
+1. **Symplectic ⇒ constraint-at-solution is impossible.** (Degenerate paper,
+   Sec. 3.4 remark.) A SPARK method cannot be symplectic *and* enforce
+   `φ(qₙ₊₁,pₙ₊₁)=0`; such methods "show reduced order of convergence or even
+   divergence."
+2. **`R(∞) ≠ 1` breaks the projection symplecticity conditions.** The code passes
+   `R∞ = (-1)^(s+1)` explicitly, so odd/even stage counts flip whether the
+   conditions hold.
+3. **Coinciding tableau pairs are singular.** The velocity `V` and the multiplier
+   `Λ` are indistinguishable when the two coefficient blocks coincide, giving a
+   degenerate (singular) stage system — most visibly at `s = 2`.
+
+## Dynamic verification added
+
+A new convergence suite `test/verification/spark_convergence_tests.jl` (wired into
+`test/runtests.jl`) measures the empirical order of every family on the degenerate
+Lotka–Volterra system in its `IDAE`/`PDAE`/`LDAE`/`HDAE` formulations, referenced
+against `Gauss(8)` on the ODE form, at `T = 1` (longer than the fixed-step
+`spark_integrators_tests.jl`, `T = 0.1`, so the true asymptotic behaviour shows).
+It asserts the documented order for the working methods (64 checks) and records the
+confirmed deficiencies as `@test_broken` at the documented order (11). Empirically
+confirmed orders:
+
+* **Full documented order:** `SLRKLobattoIII{AB,BA,D,E}` (2s−2); `SPARKGLRK(s)`
+  (2s); `SPARKGLVPRK(1)` (2); `SPARKLob{ABC,ABD}(s)` (2s−2); `TableauGausspSymplectic(2)`,
+  `TableauLobattoIII{AIIIB,BIIIA}pSymplectic(3)`, `TableauVSPARKGLRKp{Midpoint,Symplectic,Symmetric}(2)` (4);
+  `VSPARK(SPARKLobattoIIIAIIIB(3))` (4); `TableauVSPARKLobattoIIIAB(s)` and
+  `TableauVSPARKGLRKLobattoIIIAB(s)` (2s); `TableauHPARKGLRK(1)`, `HSPARK(SPARKGLRK(s))`,
+  `HSPARK(SPARKLob{ABC,ABD}(s))`, `TableauHSPARKLobattoIIIAIIIBpSymmetric(2)`.
+
+## Findings
+
+| # | Category | Method(s) | Observed | Root cause | Action |
+|:--|:---------|:----------|:---------|:-----------|:-------|
+| S1 | **B — bug (fixed)** | `TableauHSPARKGLRKLobattoIII{AB,BA,D,E}` | `BoundsError` (`s×s` matrix at `[i,σ+1]`) | `getTableauHSPARK` built the momentum projection coefficients `a_p_2`/`a_p_3` as `s×s` (`= g.a`) although the HSPARK-secondary residual indexes them over the `R = σ` projective stages; the position coefficients `a_q_2`/`a_q_3` were already the correct `s×σ`. **Incomplete port.** | **Fixed:** build `a_p_2`/`a_p_3` as the `s×σ` conjugate-symplectic partners of `α_q_2`/`α_q_3`, mirroring the `a_q_2`/`a_q_3` construction |
+| S2 | **B — bug (fixed)** | all `HSPARKsecondary` (`TableauHSPARKLobattoIII*`, `TableauHSPARKGLRKLobattoIII*`) | `SingularException` | The null-vector residual/component code was commented out while `Cache` still allocates the `μ` unknown (`cache.jl:178`), leaving an unconstrained zero row/column in the Jacobian. The working `VSPARKsecondary` has the identical block active. | **Fixed:** re-enabled the null-vector `components!`/`residual!`/`initial_guess!` blocks (matching `VSPARKsecondary`) and corrected the null-vector guess guard from the nonexistent `:λ` field to `hasnullvector`. Moved the zero pivot off the null-vector row — see S3 |
+| S3 | B — deeper (still broken) | all `HSPARKsecondary` | `SingularException` (now in the `ω` secondary-constraint block) | After S1/S2 the remaining singularity is a residual degeneracy in the `ω`-averaged secondary-constraint rows of this EXPERIMENTAL Hamiltonian method. The (incomplete) manuscripts do not give enough to reconstruct the intended coefficients with confidence, so no speculative numeric change was made. | Kept `@test_broken` with a precise, updated root cause |
+| S4 | B — latent (fixed) | `HPARK`, `HSPARKprimary` | none observed (`P = 1`) | The δ-constraint residual zeroed row `R-1` (hard-coded) while accumulating into row `i` inside a `for i in R-P+1:R` loop; they coincide only when `P = 1` (all tested methods). | **Fixed:** zero the same row `i` that is accumulated (`integrators_hspark.jl`, `integrators_hspark_primary.jl`); behaviour-neutral for `P = 1`, correct for `P > 1` |
+| S5 | **A — inherent** | `SPARKGLVPRK(2)`, `TableauHPARKGLRK(2)` | order 2 (docs 2s = 4) | `R(∞) = (-1)^{s+1} = -1` at `s = 2` violates the projection symplecticity conditions (prediction 2). This is the source's own `# maybe problem with R∞?` TODO. | `@test_broken` at order 4 |
+| S6 | **A — inherent** | `SPARKLobattoIIIAIIIB(2/3/4)`, `SPARKGLRKLobattoIII{AIIIB,BIIIA}(s)` | order-reduced (`(3)`→~2.4, `(4)`→~3.5; GLRK-Lobatto→~1) | Symplectic Lobatto pair enforcing the constraint at the solution on the degenerate Lagrangian — reduced order (predictions 1 + the known symplectic-RK-on-degenerate-Lagrangian reduction). `SPARKLobattoIIIAIIIB(2)` fails the solve outright. | `@test_broken` / documented order-reduced tolerances |
+| S7 | **A — inherent** | `SPARKLobattoIIIBIIIA(2/3/4)`, `TableauHPARKLobattoIII{AIIIB,BIIIA}(2/3)`, `TableauVSPARKLobattoIIIBIIIApSymmetric(3)` | divergence (`NonlinearSolverException`, or error 0.15–20 at `T = 0.1`) | Full divergence predicted by prediction 1; a different solver / line search / iteration cap does not help (confirmed here and in the third pass). | `@test_broken` |
+| S8 | **A — inherent** | `VSPARK(SPARK{GLRK,LobABC,LobABD,LobattoIIIAIIIB,LobattoIIIBIIIA}(2))` | `SingularException` at `s = 2` | Degenerate stage system at the lowest stage count (prediction 3). `VSPARK(SPARKLobABD(2/3))` singular at `s = 2, 3`. | `@test_broken` |
+| S9 | C — limitation (documented) | `SPARKMethod` (internal stages) | none on the degenerate test problem | `initial_guess!` zeroes the internal velocity `Vi` and `components!` never recomputes it (the `v̄` call is commented out), so `ϑ`/`f` are evaluated at `Vi = 0`. Harmless for degenerate Lagrangians (the `v`-term vanishes), but wrong in general — the code flags this in-comment. No non-degenerate DAE test problem exists here to validate a change, so a fix would be unverifiable. | Documented; not changed |
+
+## Static consistency
+
+The `components!`/`residual!`/`update!` stage equations match the docstrings and
+the manuscript stage/update equations for every family; the `SLRK` and
+`VSPARKsecondary`/`HSPARKsecondary` docstrings transcribe the paper's `(s,σ)`
+constructions faithfully. The tableau `o` fields propagate correctly from the
+underlying RungeKutta tableaus (`g.o`, `min(...)`), with the two closed-form orders
+(`lobatto_gauss_coefficients` `o = s²` and `SLRKLobattoIII` `o = 2s-2`) matching
+the code. The `docs/src/integrators/spark.md` page was expanded from a bare table
+to a description of the method families, their DAE targets, the two Butcher-tableau
+pairs, and the symplecticity/order caveats above.
+
+## Fixes applied
+
+* `src/spark/tableaus_hspark_secondary.jl` — build `a_p_2`/`a_p_3` as `s×σ`
+  conjugate-symplectic matrices (finding S1); removed the stale "not used anymore"
+  comment.
+* `src/spark/integrators_hspark_secondary.jl` — re-enabled the null-vector
+  `components!`/`residual!` blocks and fixed the `initial_guess!` guard (S2).
+* `src/spark/integrators_hspark.jl`, `src/spark/integrators_hspark_primary.jl` —
+  corrected the δ-constraint residual row index `R-1 → i` (S4).
+
+## Tests
+
+* **New** `test/verification/spark_convergence_tests.jl` (wired into
+  `test/runtests.jl`): 64 order assertions + 11 `@test_broken` deficiencies.
+* `test/spark/spark_integrators_tests.jl` — the HSPARK-secondary testset comment
+  was updated to the S1–S3 root cause and the calls wrapped in `muffle` (the fixed
+  methods now iterate in the solver before failing, rather than aborting
+  immediately). Tally unchanged at **133 pass / 45 broken**.
+
+The integrator machinery is correct: every SPARK family that is *not* subject to an
+inherent instability (SLRK, SPARK-Gauß, SPARK-Lobatto ABC/ABD, VSPARK/VPARK
+symplectic-projection, VSPARK-secondary, HSPARK-Gauß/Lobatto ABC/ABD) reaches
+exactly its documented order. The non-converging cases are, with the exception of
+the EXPERIMENTAL HSPARK-secondary family (S3), **inherent method properties**
+(order reduction / divergence / singular stage systems predicted by the
+manuscripts), not implementation defects.

--- a/docs/src/integrators/spark.md
+++ b/docs/src/integrators/spark.md
@@ -22,3 +22,64 @@ GeometricIntegrators.jl provides several flavours of such SPARK methods (*some a
 | [`IntegratorVSPARKsecondary`](@ref) | Degenerate Lagrangian system enforcing primary & secondary Dirac constraint                          |
 
 These integrators are applied to either an `IDAE`, `HDAE` or `LDAE`.
+
+## Construction
+
+A SPARK method combines two Runge–Kutta tableaus: an *internal* pair
+``(a_{ij}, b_i)`` on ``s`` stages that advances the dynamics, and a *projective*
+(or *constraint*) pair ``(\tilde{a}_{ij}, \tilde{b}_i)`` on ``r`` stages that
+enforces the algebraic constraint. Writing the vector field in the additive split
+``f = f^{1} + f^{2} + f^{3}`` (Hamiltonian part, fibre-derivative part, constraint
+part), the internal stages read
+
+```math
+\begin{aligned}
+Q_{n,i} &= q_{n} + h \sum_{j=1}^{s} a_{ij} V_{n,j} + h \sum_{j=1}^{r} \alpha_{ij} U_{n,j} , \\
+P_{n,i} &= p_{n} + h \sum_{j=1}^{s} a_{ij} F_{n,j} + h \sum_{j=1}^{r} \alpha_{ij} G_{n,j} ,
+\end{aligned}
+```
+
+the projective stages carry the Lagrange multipliers ``\Lambda_{n,i}`` and the
+projective forces ``U_{n,i}``, ``G_{n,i}``, and the constraint is averaged over the
+projective stages,
+
+```math
+0 = \sum_{j=1}^{r} \omega_{ij} \, \tilde{\Phi}_{n,j} + \omega_{i,r+1} \, \phi(q_{n+1}, p_{n+1}) ,
+\qquad i = 1, \dots, r ,
+```
+
+with the last row of ``\omega`` selecting the constraint ``\phi(q_{n+1},p_{n+1})``
+at the solution. The building blocks live in `RungeKutta.jl` (Gauß/Lobatto
+tableaus) and in `src/spark/` (`gauss_ω_matrix`, `lobatto_ω_matrix`,
+`lobatto_gauss_coefficients`, `get_lobatto_nullvector`); the concrete method
+factories `SPARKGLRK`, `SPARKLob{ABC,ABD}`, `TableauVSPARK…`, `TableauHSPARK…`,
+`SLRKLobatto…` assemble the internal/projective pairs.
+
+The *degenerate variational* (`VSPARK`, `SLRK`) and *Dirac-constraint* (`HSPARK`)
+families additionally enforce the **secondary** constraint
+``\psi = \dot{p} - \nabla\vartheta(q)\cdot v = 0`` (the time derivative of the
+primary constraint), following [[Kraus:2020](@cite)].
+
+## Order and stability caveats
+
+Verification against the source manuscripts and empirical convergence measurement
+(see `test/verification/spark_convergence_tests.jl` and the SPARK-submodule pass in
+the repository's verification report) established that several SPARK methods do not
+reach — or do not converge to — their nominal order. These are **inherent
+properties of the methods**, not implementation defects:
+
+* A SPARK method cannot be simultaneously symplectic and enforce the constraint
+  ``\phi(q_{n+1},p_{n+1}) = 0`` at the solution. Methods that do so (e.g. the
+  Lobatto `IIIA-IIIB` / `IIIB-IIIA` `SPARK`/`HPARK` pairs) exhibit reduced order or
+  divergence on the degenerate Lotka–Volterra system.
+* The projection symplecticity conditions require ``R(\infty) = 1``. Since the
+  implementation uses ``R(\infty) = (-1)^{s+1}``, the Gauß-based `SPARKGLVPRK` and
+  `HPARKGLRK` methods drop from order ``2s`` to order ``2`` at ``s = 2``.
+* Tableau pairs that coincide give a degenerate (singular) stage system, most
+  visibly at ``s = 2`` (`VSPARK(SPARK…(2))`).
+
+Methods that are *not* subject to these obstructions — `SLRK`, `SPARKGLRK`,
+`SPARKLob{ABC,ABD}`, the symplectic-projection `VPARK`/`VSPARK` variants,
+`VSPARKsecondary`, and `HSPARK` on Gauß / Lobatto `ABC`/`ABD` — reach exactly their
+documented order (Gauß ``2s``, Lobatto ``2s-2``). The `HSPARKsecondary` family is
+**experimental** and currently raises a `SingularException`.

--- a/src/spark/integrators_hspark.jl
+++ b/src/spark/integrators_hspark.jl
@@ -174,7 +174,7 @@ function residual!(b::AbstractVector{ST}, x::AbstractVector{ST}, sol, params, in
     # compute b = d_λ ⋅ Λ
     for i in R-P+1:R
         for k in 1:D
-            b[2*D*S+3*(D*(R-1)+k-1)+3] = 0
+            b[2*D*S+3*(D*(i-1)+k-1)+3] = 0
             for j in 1:R
                 b[2*D*S+3*(D*(i-1)+k-1)+3] -= tableau(int).δ[j] * C.Λp[j][k]
             end

--- a/src/spark/integrators_hspark_primary.jl
+++ b/src/spark/integrators_hspark_primary.jl
@@ -173,7 +173,7 @@ function residual!(b::AbstractVector{ST}, x::AbstractVector{ST}, sol, params, in
     # compute b = d_λ ⋅ Λ
     for i in R-P+1:R
         for k in 1:D
-            b[2*D*S+3*(D*(R-1)+k-1)+3] = 0
+            b[2*D*S+3*(D*(i-1)+k-1)+3] = 0
             for j in 1:R
                 b[2*D*S+3*(D*(i-1)+k-1)+3] -= tableau(int).δ[j] * C.Λp[j][k]
             end

--- a/src/spark/integrators_hspark_secondary.jl
+++ b/src/spark/integrators_hspark_secondary.jl
@@ -133,7 +133,7 @@ function initial_guess!(sol, history, params, int::GeometricIntegrator{<:Union{H
         end
     end
 
-    if isdefined(tableau(int), :λ) && tableau(int).λ.c[1] == 0
+    if hasnullvector(method(int))
         for k in 1:D
             C.x[2*D*nstages(int)+4*D*pstages(method(int))+k] = 0
         end
@@ -190,11 +190,11 @@ function components!(x::AbstractVector{ST}, sol, params, int::GeometricIntegrato
         equations(int).ψ(C.Ψp[i], t, C.Qp[i], C.Pp[i], C.Vp[i], C.Fp[i], params)
     end
 
-    # if hasnullvector(method(int))
-    #     for k in 1:D
-    #         C.μ[k] = x[2*D*S+4*D*R+k]
-    #     end
-    # end
+    if hasnullvector(method(int))
+        for k in 1:D
+            C.μ[k] = x[2*D*S+4*D*R+k]
+        end
+    end
 
     # compute q and p
     C.q̃ .= sol.q
@@ -269,20 +269,20 @@ function residual!(b::AbstractVector{ST}, x::AbstractVector{ST}, sol, params, in
         end
     end
 
-    # if hasnullvector(method(int))
-    #     for i in 1:R
-    #         for k in 1:D
-    #             b[2*D*S+4*(D*(i-1)+k-1)+2] -= C.μ[k] * tableau(int).d[i] / tableau(int).p.b[2][i]
-    #         end
-    #     end
+    if hasnullvector(method(int))
+        for i in 1:R
+            for k in 1:D
+                b[2*D*S+4*(D*(i-1)+k-1)+2] -= C.μ[k] * tableau(int).d[i] / tableau(int).p.b[2][i]
+            end
+        end
 
-    #     for k in 1:D
-    #         b[2*D*S+4*D*R+k] = 0
-    #         for i in 1:R
-    #             b[2*D*S+4*D*R+k] -= C.Vp[i][k] * tableau(int).d[i]
-    #         end
-    #     end
-    # end
+        for k in 1:D
+            b[2*D*S+4*D*R+k] = 0
+            for i in 1:R
+                b[2*D*S+4*D*R+k] -= C.Vp[i][k] * tableau(int).d[i]
+            end
+        end
+    end
 end
 
 

--- a/src/spark/integrators_spark.jl
+++ b/src/spark/integrators_spark.jl
@@ -153,11 +153,12 @@ function components!(x::AbstractVector{ST}, sol, params, int::GeometricIntegrato
         end
 
         # compute f(X)
-        # TODO: Solve Problem !!!
-        # The function f depends von v but Vi has never been initialized !
-        # For degenerate Lagrangians this might be just right, as the corresponding
-        # term in F that multiplies v should not be there in the first place
-        # (cf. SPARK paper) but in general this will cause problems
+        # TODO: Solve Problem !!!  (VERIFICATION_REPORT.md, SPARK submodule pass, finding S9)
+        # The function f depends on v but Vi has never been initialized (initial_guess!
+        # zeroes it and it is never recomputed here). For degenerate Lagrangians this is
+        # correct, as the corresponding term in F that multiplies v vanishes (cf. SPARK
+        # paper), but in general this will cause problems. Left unchanged because no
+        # non-degenerate DAE test problem exists here to validate a fix.
         # tqᵢ = solstep(int).t̄ + timestep(int) * tableau(int).q.c[i]
         tpᵢ = sol.t + timestep(int) * (tableau(int).p.c[i] - 1)
         # equations(int).v̄(C.Vi[i], tqᵢ, C.Qi[i], C.Pi[i], params)

--- a/src/spark/tableaus_hspark_secondary.jl
+++ b/src/spark/tableaus_hspark_secondary.jl
@@ -21,16 +21,30 @@ function getTableauHSPARK(s, σ, o, tsym, g, h, lq, lp, ω, d=nothing)
     α_q_1 = h.a
     α_p_1 = h.a
 
-    # a_p_1, a_p_2 and a_p_3 are free (they are not used in HSPARKpSecondary integrators anymore)
-    # REALLY?
     a_q_1 = g.a
     b_q_1 = g.b
 
     a_p_1 = g.a
     b_p_1 = g.b
 
-    a_p_2 = g.a
-    a_p_3 = g.a
+    # a_p_2 and a_p_3 couple the internal momentum increment Z_i (i = 1..s) to the
+    # projective forces G_p / G̅_p (j = 1..σ) in the HSPARKsecondary residual, so they
+    # must be s×σ, not s×s. They are the conjugate-symplectic partners of the projective
+    # position coefficients α_q_2 / α_q_3 (mirroring the a_q_2 / a_q_3 construction below
+    # with the roles of q and p swapped): b_p_2_j a_p_2_ij + b_q_1_i α_q_2_ji = b_q_1_i b_p_2_j.
+    a_p_2 = zeros(s,σ)
+    for i in 1:s
+        for j in 1:σ
+            a_p_2[i,j] = b_p_2[j] / b_q_1[i] * (b_q_1[i] - α_q_2[j,i])
+        end
+    end
+
+    a_p_3 = zeros(s,σ)
+    for i in 1:s
+        for j in 1:σ
+            a_p_3[i,j] = b_p_3[j] / b_q_1[i] * (b_q_1[i] - α_q_3[j,i])
+        end
+    end
 
     β_q_1 = lq.b
     β_q_2 = lq.b

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,6 +74,9 @@ end
 @safetestset "Convergence: Projected Integrators                                              " begin
     include("verification/projection_convergence_tests.jl")
 end
+@safetestset "Convergence: SPARK Integrators                                                  " begin
+    include("verification/spark_convergence_tests.jl")
+end
 
 @safetestset "Method Tests                                                                    " begin
     include("methods/methods_tests.jl")

--- a/test/spark/spark_integrators_tests.jl
+++ b/test/spark/spark_integrators_tests.jl
@@ -620,28 +620,27 @@ end
 
     ### HSPARKsecondary Integrators ###
 
-    # The q̇/v interface incompatibility (the integrator built the initial-guess
-    # NamedTuple with fields `v`/`f` instead of the `q̇`/`ṗ` that `solutionstep!`
-    # consumes) has been FIXED in src/spark/integrators_hspark_secondary.jl, so
-    # these methods now run through the solver instead of raising a FieldError.
-    # They still do not converge, for two separate pre-existing SPARK issues
-    # (see VERIFICATION_REPORT.md):
-    #   * TableauHSPARKLobattoIII{AB,BA,D,E} — singular stage system
-    #     (SingularException at all orders).
-    #   * TableauHSPARKGLRKLobattoIII{AB,BA,D,E} — out-of-bounds tableau access
-    #     (BoundsError: s×s coefficient matrix indexed at [1, s+1]).
-    # Recorded as @test_broken until those numerical issues are resolved.
-
+    # HSPARKsecondary is EXPERIMENTAL and remains @test_broken (see the "SPARK
+    # submodule" pass in VERIFICATION_REPORT.md). Two implementation bugs were fixed:
+    #   * the momentum projection coefficients a_p_2 / a_p_3 in getTableauHSPARK were
+    #     s×s instead of s×σ, so the GLRK variants raised a BoundsError — now built as
+    #     the conjugate-symplectic s×σ partners of α_q_2 / α_q_3;
+    #   * the null-vector residual/component code was commented out while the cache
+    #     still allocated the μ unknown, leaving an unconstrained (zero) Jacobian row —
+    #     now re-enabled, matching the working VSPARKsecondary.
+    # A residual singularity remains in the ω secondary-constraint block: every variant
+    # still raises a SingularException, so all cases stay @test_broken. The solves now
+    # iterate before failing (they no longer abort immediately), so they are muffled.
     for s in (2, 3, 4)
-        @test_broken relative_maximum_error(integrate(hdae, TableauHSPARKLobattoIIIAB(s)).q, ref.q) < 1E-6
-        @test_broken relative_maximum_error(integrate(hdae, TableauHSPARKLobattoIIIBA(s)).q, ref.q) < 1E-6
-        @test_broken relative_maximum_error(integrate(hdae, TableauHSPARKLobattoIIID(s)).q, ref.q) < 1E-6
-        @test_broken relative_maximum_error(integrate(hdae, TableauHSPARKLobattoIIIE(s)).q, ref.q) < 1E-6
+        @test_broken relative_maximum_error(muffle(() -> integrate(hdae, TableauHSPARKLobattoIIIAB(s))).q, ref.q) < 1E-6
+        @test_broken relative_maximum_error(muffle(() -> integrate(hdae, TableauHSPARKLobattoIIIBA(s))).q, ref.q) < 1E-6
+        @test_broken relative_maximum_error(muffle(() -> integrate(hdae, TableauHSPARKLobattoIIID(s))).q, ref.q) < 1E-6
+        @test_broken relative_maximum_error(muffle(() -> integrate(hdae, TableauHSPARKLobattoIIIE(s))).q, ref.q) < 1E-6
 
-        @test_broken relative_maximum_error(integrate(hdae, TableauHSPARKGLRKLobattoIIIAB(s)).q, ref.q) < 4E-6
-        @test_broken relative_maximum_error(integrate(hdae, TableauHSPARKGLRKLobattoIIIBA(s)).q, ref.q) < 4E-6
-        @test_broken relative_maximum_error(integrate(hdae, TableauHSPARKGLRKLobattoIIID(s)).q, ref.q) < 4E-6
-        @test_broken relative_maximum_error(integrate(hdae, TableauHSPARKGLRKLobattoIIIE(s)).q, ref.q) < 4E-6
+        @test_broken relative_maximum_error(muffle(() -> integrate(hdae, TableauHSPARKGLRKLobattoIIIAB(s))).q, ref.q) < 4E-6
+        @test_broken relative_maximum_error(muffle(() -> integrate(hdae, TableauHSPARKGLRKLobattoIIIBA(s))).q, ref.q) < 4E-6
+        @test_broken relative_maximum_error(muffle(() -> integrate(hdae, TableauHSPARKGLRKLobattoIIID(s))).q, ref.q) < 4E-6
+        @test_broken relative_maximum_error(muffle(() -> integrate(hdae, TableauHSPARKGLRKLobattoIIIE(s))).q, ref.q) < 4E-6
     end
 
 end

--- a/test/verification/spark_convergence_tests.jl
+++ b/test/verification/spark_convergence_tests.jl
@@ -1,0 +1,142 @@
+using GeometricIntegrators
+using GeometricIntegrators.SPARK
+using GeometricProblems.LotkaVolterra2d
+using RungeKutta
+using Test
+
+include("verification_utilities.jl")
+
+# Dynamic (multi-Δt) convergence verification for the SPARK family, mirroring the
+# other test/verification/*_convergence_tests.jl suites. SPARK methods integrate the
+# degenerate Lotka–Volterra system in its various DAE formulations; the reference is
+# a high-order Gauß collocation of the ODE form at the matching Δt. Expected orders
+# are the tableau `o` fields (Gauß 2s, Lobatto-pair 2s−2). Confirmed order
+# deficiencies / divergent / singular methods are recorded as @test_broken at the
+# documented order with a root-cause tag — see the "SPARK submodule" pass in
+# VERIFICATION_REPORT.md for the A/B/C classification.
+
+const q₀ = [1.0, 1.0]
+const params = (a₁ = 1.0, a₂ = 1.0, b₁ = -1.0, b₂ = -2.0)
+const T = 1.0
+
+steps(n0, k) = T ./ (n0 .* 2 .^ (0:k))
+emq(sol, ref) = relative_maximum_error(sol.q, ref.q)
+
+# Reference: Gauß(8) collocation of the ODE form at the same Δt.
+href(Δt) = integrate(odeproblem(q₀; timespan = (0.0, T), timestep = Δt, parameters = params), Gauss(8))
+ref_ode(prob) = href(timestep(prob))
+
+build_idae(Δt)      = idaeproblem(q₀; timespan = (0.0, T), timestep = Δt, parameters = params)
+build_pdae(Δt)      = pdaeproblem(q₀; timespan = (0.0, T), timestep = Δt, parameters = params)
+build_ldae(Δt)      = ldaeproblem(q₀; timespan = (0.0, T), timestep = Δt, parameters = params)
+build_hdae(Δt)      = hdaeproblem(q₀; timespan = (0.0, T), timestep = Δt, parameters = params)
+build_ldae_slrk(Δt) = ldaeproblem_slrk(q₀; timespan = (0.0, T), timestep = Δt, parameters = params)
+
+# Suppress the (correct) solver-divergence log spam from the broken cases.
+muffle(f) = Base.CoreLogging.with_logger(f, Base.CoreLogging.NullLogger())
+
+# @test_broken helper for methods that do not converge, diverge, or raise
+# SingularException / NonlinearSolverException. The measurement is muffled and any
+# thrown exception is recorded as broken (that is exactly the deficiency under test).
+function broken_order(builder, method, tsteps, expected; label)
+    @testset "$(label): order ≈ $(expected) (broken)" begin
+        ok = try
+            r = muffle(() -> estimate_convergence_order(builder, method, tsteps;
+                reference = ref_ode, errormetric = emq, plateau = 5e-13))
+            isapprox(r.order, expected; atol = 0.4)
+        catch
+            false
+        end
+        @test_broken ok
+    end
+end
+
+conv(builder, method, tsteps, expected; label) =
+    muffle(() -> test_convergence_order(builder, method, tsteps; reference = ref_ode,
+        errormetric = emq, expected = expected, atol = 0.4, plateau = 5e-13, label = label))
+
+
+@testset "SPARK convergence" begin
+
+    @testset "SLRK (LDAE)" begin
+        conv(build_ldae_slrk, SLRKLobattoIIIAB(2), steps(20, 3), 2; label = "SLRKLobattoIIIAB(2)")
+        conv(build_ldae_slrk, SLRKLobattoIIIBA(2), steps(20, 3), 2; label = "SLRKLobattoIIIBA(2)")
+        conv(build_ldae_slrk, SLRKLobattoIIID(2),  steps(20, 3), 2; label = "SLRKLobattoIIID(2)")
+        conv(build_ldae_slrk, SLRKLobattoIIIE(2),  steps(20, 3), 2; label = "SLRKLobattoIIIE(2)")
+        conv(build_ldae_slrk, SLRKLobattoIIIAB(3), steps(20, 3), 4; label = "SLRKLobattoIIIAB(3)")
+        conv(build_ldae_slrk, SLRKLobattoIIIBA(3), steps(20, 3), 4; label = "SLRKLobattoIIIBA(3)")
+        conv(build_ldae_slrk, SLRKLobattoIIID(3),  steps(20, 3), 4; label = "SLRKLobattoIIID(3)")
+        conv(build_ldae_slrk, SLRKLobattoIIIE(3),  steps(20, 3), 4; label = "SLRKLobattoIIIE(3)")
+    end
+
+    @testset "SPARK (IDAE)" begin
+        conv(build_idae, SPARKGLRK(1),   steps(20, 3), 2; label = "SPARKGLRK(1)")
+        conv(build_idae, SPARKGLRK(2),   steps(20, 3), 4; label = "SPARKGLRK(2)")
+        conv(build_idae, SPARKGLVPRK(1), steps(20, 3), 2; label = "SPARKGLVPRK(1)")
+        conv(build_idae, SPARKLobABC(2), steps(20, 3), 2; label = "SPARKLobABC(2)")
+        conv(build_idae, SPARKLobABC(3), steps(20, 3), 4; label = "SPARKLobABC(3)")
+        conv(build_idae, SPARKLobABD(2), steps(20, 3), 2; label = "SPARKLobABD(2)")
+        conv(build_idae, SPARKLobABD(3), steps(20, 3), 4; label = "SPARKLobABD(3)")
+    end
+
+    @testset "VPARK / VSPARK primary (IDAE)" begin
+        conv(build_idae, TableauGausspSymplectic(2),            steps(20, 3), 4; label = "TableauGausspSymplectic(2)")
+        conv(build_idae, TableauLobattoIIIAIIIBpSymplectic(3),  steps(20, 3), 4; label = "LobattoIIIAIIIBpSymplectic(3)")
+        conv(build_idae, TableauLobattoIIIBIIIApSymplectic(3),  steps(20, 3), 4; label = "LobattoIIIBIIIApSymplectic(3)")
+        conv(build_idae, TableauVSPARKGLRKpMidpoint(2),         steps(20, 3), 4; label = "VSPARKGLRKpMidpoint(2)")
+        conv(build_idae, TableauVSPARKGLRKpSymplectic(2),       steps(20, 3), 4; label = "VSPARKGLRKpSymplectic(2)")
+        conv(build_idae, TableauVSPARKGLRKpSymmetric(2),        steps(20, 3), 4; label = "VSPARKGLRKpSymmetric(2)")
+    end
+
+    @testset "VSPARK general (IDAE)" begin
+        conv(build_idae, VSPARK(SPARKLobattoIIIAIIIB(3)), steps(20, 3), 4; label = "VSPARK(SPARKLobattoIIIAIIIB(3))")
+    end
+
+    @testset "VSPARK secondary (LDAE)" begin
+        conv(build_ldae, TableauVSPARKLobattoIIIAB(2),     steps(20, 3), 2; label = "VSPARKLobattoIIIAB(2)")
+        conv(build_ldae, TableauVSPARKLobattoIIIAB(3),     steps(20, 3), 4; label = "VSPARKLobattoIIIAB(3)")
+        conv(build_ldae, TableauVSPARKGLRKLobattoIIIAB(1), steps(20, 3), 2; label = "VSPARKGLRKLobattoIIIAB(1)")
+        conv(build_ldae, TableauVSPARKGLRKLobattoIIIAB(2), steps(20, 3), 4; label = "VSPARKGLRKLobattoIIIAB(2)")
+    end
+
+    @testset "HPARK / HSPARK (PDAE)" begin
+        conv(build_pdae, TableauHPARKGLRK(1),                     steps(20, 3), 2; label = "HPARKGLRK(1)")
+        conv(build_pdae, HSPARK(SPARKGLRK(1)),                    steps(20, 3), 2; label = "HSPARK(SPARKGLRK(1))")
+        conv(build_pdae, HSPARK(SPARKGLRK(2)),                    steps(20, 3), 4; label = "HSPARK(SPARKGLRK(2))")
+        conv(build_pdae, HSPARK(SPARKLobABC(3)),                  steps(20, 3), 4; label = "HSPARK(SPARKLobABC(3))")
+        conv(build_pdae, HSPARK(SPARKLobABD(3)),                  steps(20, 3), 4; label = "HSPARK(SPARKLobABD(3))")
+        conv(build_pdae, TableauHSPARKLobattoIIIAIIIBpSymmetric(2), steps(20, 3), 2; label = "HSPARKLobattoIIIAIIIBpSymmetric(2)")
+    end
+
+    # ---------------------------------------------------------------------------
+    # Known deficiencies (see VERIFICATION_REPORT.md, SPARK submodule pass). These
+    # are inherent properties of the methods (category A), not implementation bugs:
+    #   * R(∞) ≠ 1 at even σ̃ reduces the GL-VPRK / GL-HPARK order 2s → 2;
+    #   * symplectic Lobatto pairs enforcing the constraint at the solution reduce
+    #     order or diverge on the degenerate Lagrangian (papers, Sec. 3.4);
+    #   * the s = 2 pairs give a degenerate (singular) stage system.
+    # HSPARK-secondary Lobatto (below) remains @test_broken for an implementation
+    # reason (category B): a residual singularity in the ω secondary-constraint block.
+    # ---------------------------------------------------------------------------
+    @testset "Known deficiencies (broken)" begin
+        # R(∞) = -1 order reduction 2s → 2
+        broken_order(build_idae, SPARKGLVPRK(2),      steps(20, 3), 4; label = "SPARKGLVPRK(2)")
+        broken_order(build_pdae, TableauHPARKGLRK(2), steps(20, 3), 4; label = "HPARKGLRK(2)")
+
+        # symplectic Lobatto-pair order reduction / divergence on the degenerate system
+        broken_order(build_idae, SPARKLobattoIIIAIIIB(3),        steps(20, 3), 4; label = "SPARKLobattoIIIAIIIB(3)")
+        broken_order(build_idae, SPARKGLRKLobattoIIIAIIIB(2),    steps(20, 3), 4; label = "SPARKGLRKLobattoIIIAIIIB(2)")
+        broken_order(build_idae, SPARKLobattoIIIBIIIA(2),        steps(10, 2), 2; label = "SPARKLobattoIIIBIIIA(2)")
+        broken_order(build_pdae, TableauHPARKLobattoIIIAIIIB(2), steps(10, 2), 2; label = "HPARKLobattoIIIAIIIB(2)")
+        broken_order(build_idae, TableauVSPARKLobattoIIIBIIIApSymmetric(3), steps(10, 2), 4; label = "VSPARKLobattoIIIBIIIApSymmetric(3)")
+
+        # singular stage system at s = 2
+        broken_order(build_idae, VSPARK(SPARKLobABC(2)),          steps(10, 1), 2; label = "VSPARK(SPARKLobABC(2))")
+        broken_order(build_idae, VSPARK(SPARKLobattoIIIAIIIB(2)), steps(10, 1), 2; label = "VSPARK(SPARKLobattoIIIAIIIB(2))")
+
+        # HSPARK-secondary: residual singularity in the ω secondary-constraint block
+        broken_order(build_hdae, TableauHSPARKLobattoIIIAB(2),     steps(10, 1), 2; label = "TableauHSPARKLobattoIIIAB(2)")
+        broken_order(build_hdae, TableauHSPARKGLRKLobattoIIIAB(2), steps(10, 1), 4; label = "TableauHSPARKGLRKLobattoIIIAB(2)")
+    end
+
+end


### PR DESCRIPTION
## Summary

Completes the integrator-verification effort (`VERIFICATION_REPORT.md`) by covering the **SPARK submodule** with a static + dynamic pass, and diagnoses why several SPARK methods do not converge. Reference basis: the two SPARK manuscripts (which prove *symplecticity* but defer order/convergence analysis to Jay's papers), plus empirical convergence measurement.

## Why SPARK methods don't converge

Most non-convergence is an **inherent property of the methods, not a bug** — confirmed against three predictions from the manuscripts:

- **Symplectic + constraint-at-solution is impossible** → Lobatto `IIIA-IIIB`/`IIIB-IIIA` SPARK/HPARK pairs reduce order or diverge on the degenerate system.
- **Projection requires `R(∞)=1`** but the code uses `R∞=(-1)^{s+1}` → `SPARKGLVPRK(2)`, `HPARKGLRK(2)` drop from order `2s` to `2` at `s=2`.
- **Coinciding tableau pairs are singular** → `VSPARK(SPARK…(2))` raises `SingularException` at `s=2`.

These are recorded as `@test_broken` at the documented order with cited root causes (findings S5–S8).

## Implementation bugs fixed (findings S1–S4)

- **HSPARK-secondary `BoundsError`**: `getTableauHSPARK` built the momentum projection coefficients `a_p_2`/`a_p_3` as `s×s` although the residual indexes them over the `σ` projective stages (incomplete port). Rebuilt as the `s×σ` conjugate-symplectic partners of `α_q_2`/`α_q_3`.
- **HSPARK-secondary `SingularException`**: the null-vector residual/component code was commented out while the cache still allocated the `μ` unknown, leaving an unconstrained Jacobian row. Re-enabled it (matching the working `VSPARK-secondary`) and fixed the `initial_guess!` guard. A deeper singularity remains in its ω secondary-constraint block; this EXPERIMENTAL family stays `@test_broken`.
- **δ-constraint residual row index** `R-1 → i` in `integrators_hspark.jl` / `integrators_hspark_primary.jl` (neutral for `P=1`, correct for `P>1`).
- Documented (not changed) the `SPARKMethod` `Vi=0` limitation — provably neutral on the degenerate test problem and unverifiable without a non-degenerate DAE case (finding S9).

## Tests & docs

- **New** `test/verification/spark_convergence_tests.jl` (wired into `runtests.jl`): 64 order assertions + 11 `@test_broken` deficiencies.
- Expanded `docs/src/integrators/spark.md` with the construction and order/stability caveats.
- Full findings table (S1–S9, categorized inherent / bug / limitation) appended to `VERIFICATION_REPORT.md`.

## Verification

Full test suite passes (the repo's pre-push hook ran it). SPARK tally unchanged at **133 pass / 45 broken**; new SPARK convergence suite **64 pass / 11 broken**; tableaus **129 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)