### PR TITLE
Require GeometricProblems 0.8, and quiet the test suite

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,6 +28,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+Aqua = "0.8"
 CompactBasisFunctions = "0.2"
 Documenter = "1"
 GenericLinearAlgebra = "0.2, 0.3, 0.4"
@@ -44,8 +45,11 @@ ProgressMeter = "1"
 QuadratureRules = "0.1"
 Reexport = "1.0"
 RungeKutta = "0.5.23"
+SafeTestsets = "0.1"
+SharedArrays = "1"
 SimpleSolvers = "0.9"
 StaticArrays = "1"
+Test = "1"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GeometricIntegrators"
 uuid = "dcce2d33-59f6-5b8d-9047-0defad88ae06"
-version = "0.16.9"
+version = "0.16.10"
 authors = ["Michael Kraus <michael.kraus@ipp.mpg.de>"]
 
 [workspace]
@@ -34,7 +34,7 @@ GenericLinearAlgebra = "0.2, 0.3, 0.4"
 GeometricBase = "0.14"
 GeometricEquations = "0.21"
 GeometricIntegratorsBase = "0.3, 0.4"
-GeometricProblems = "0.7.2"
+GeometricProblems = "0.8"
 GeometricSolutions = "0.6.5"
 LinearAlgebra = "1"
 OffsetArrays = "1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -12,5 +12,20 @@ GeometricSolutions = "7843afe4-64f4-4df4-9231-049495c56661"
 RungeKutta = "fb486d5c-30a0-4a8a-8415-a8b4ace5a6f7"
 Weave = "44d3d7a6-8a23-5bf8-98c5-b353f8df5ec9"
 
+# See the note in test/Project.toml: GeometricProblems and the documentation tooling are
+# dependencies of this project, so their bounds belong here, not in the root Project.toml.
+[compat]
+CairoMakie = "0.15"
+Documenter = "1"
+DocumenterCitations = "1.4"
+DocumenterInterLinks = "1.1"
+GeometricBase = "0.14"
+GeometricEquations = "0.21"
+GeometricIntegratorsBase = "0.3, 0.4"
+GeometricProblems = "0.8"
+GeometricSolutions = "0.6.5"
+RungeKutta = "0.5.23"
+Weave = "0.10"
+
 [sources]
 GeometricIntegrators = {path = ".."}

--- a/docs/src/audit.md
+++ b/docs/src/audit.md
@@ -490,8 +490,17 @@ ways:
 (`min_iterations=1, x_suctol=2eps(), f_abstol=8eps(), f_suctol=2eps()`,
 `src/spark/abstract.jl`). For `VSPARK(SPARKLobABD(4))` the same machine-precision
 `f_abstol` stall as PMVI/HP applies; relaxing it to `4e-15` (keeping the other
-SPARK defaults, threaded via the module-level `SPARK_RELAXED` named tuple) makes
-the solve converge and removes **both** warning kinds, error unchanged (5.2e-12).
+SPARK defaults, threaded via a module-level `SPARK_RELAXED` named tuple) made the
+solve converge and removed **both** warning kinds, error unchanged (5.2e-12).
+
+**Update (SimpleSolvers 0.9.2).** The line search has since been reworked and the
+counts above no longer hold: the whole suite now emits **12** warnings per run, all
+of the line-search kind, and all from that one relaxed `VSPARK(SPARKLobABD(4))`
+call — with the framework defaults it warns just *once*, at the same 5.2e-12 error,
+so the relaxation now costs warnings instead of removing them. `SPARK_RELAXED` was
+therefore dropped and that call muffled like the rest; `VSPARK(SPARKLobABC(3))`
+(19 line-search warnings before, 1 now) and `VSPARK(SPARKLobABD(3))` (2 solver +
+18 line-search) stay muffled, and every other passing case warns zero times.
 
 For every other noisy case, tolerance/solver tuning does **not** cleanly help —
 the divergent methods genuinely fail, and the line-search warning cannot be

--- a/docs/src/audit.md
+++ b/docs/src/audit.md
@@ -643,7 +643,8 @@ numerical.
 Findings 13, 14, 16, 17, 20, 24 and 25 were implementation bugs in this repository and are
 **fixed**. Findings 18, 19 and 21 are inherent properties of the methods, now asserted
 or recorded. Finding 15 corrects this report; 22 corrects the test suite; 23 was a stale
-dependency bound, now restricted to `GeometricProblems = "0.7"`.
+dependency bound, restricted to `GeometricProblems = "0.7"` at the time of the audit and
+since moved on to `"0.8"`.
 
 Note that 24 is the one place where the port asserted a structural property that does not
 hold: the same standard applied to `FLRK` (`issymplectic = missing`, because the reference

--- a/src/integrators/dvi/dvi_trapezoidal.jl
+++ b/src/integrators/dvi/dvi_trapezoidal.jl
@@ -96,8 +96,8 @@ function initial_guess!(sol, history, params, int::GeometricIntegrator{<:CTDVI})
     offset_v = D
     offset_x = D + div(D, 2)
     for k in 1:div(D, 2)
-        cache(int).x[offset_v+k] = cache(int).v[k]              # v¹(n+1/2)
-        cache(int).x[offset_x+k] = cache(int).q[div(D, 2)+k]     # q²(n+1/2)
+        x[offset_v+k] = cache(int).v[k]              # v¹(n+1/2)
+        x[offset_x+k] = cache(int).q[div(D, 2)+k]     # q²(n+1/2)
     end
 end
 

--- a/src/spark/integrators_hpark.jl
+++ b/src/spark/integrators_hpark.jl
@@ -52,8 +52,8 @@ function Base.show(io::IO, int::IntegratorHPARK)
     print(io, "\nto Dirac constraints *EXPERIMENTAL*\n")
     print(io, "   Timestep: $(timestep(int))\n")
     print(io, "   Tableau:  $(description(method(int)))\n")
-    print(io, "   $(string(method(int).q))")
-    print(io, "   $(string(method(int).p))")
+    print(io, "   $(string(tableau(method(int)).q))")
+    print(io, "   $(string(tableau(method(int)).p))")
     # print(io, reference(method(int)))
 end
 

--- a/src/spark/integrators_hspark.jl
+++ b/src/spark/integrators_hspark.jl
@@ -51,8 +51,8 @@ function Base.show(io::IO, int::IntegratorHSPARK)
     print(io, "\nSpecialised Partitioned Additive Runge-Kutta integrator for Hamiltonian systems *EXPERIMENTAL*\n")
     print(io, "   Timestep: $(timestep(int))\n")
     print(io, "   Tableau:  $(description(method(int)))\n")
-    print(io, "   $(string(method(int).q))")
-    print(io, "   $(string(method(int).p))")
+    print(io, "   $(string(tableau(method(int)).q))")
+    print(io, "   $(string(tableau(method(int)).p))")
     # print(io, reference(method(int)))
 end
 

--- a/src/spark/integrators_hspark_primary.jl
+++ b/src/spark/integrators_hspark_primary.jl
@@ -50,8 +50,8 @@ function Base.show(io::IO, int::IntegratorHSPARKprimary)
     print(io, "\nwith projection on primary constraint *EXPERIMENTAL*\n")
     print(io, "   Timestep: $(timestep(int))\n")
     print(io, "   Tableau:  $(description(method(int)))\n")
-    print(io, "   $(string(method(int).q))")
-    print(io, "   $(string(method(int).p))")
+    print(io, "   $(string(tableau(method(int)).q))")
+    print(io, "   $(string(tableau(method(int)).p))")
     # print(io, reference(method(int)))
 end
 

--- a/src/spark/integrators_hspark_secondary.jl
+++ b/src/spark/integrators_hspark_secondary.jl
@@ -87,8 +87,8 @@ function Base.show(io::IO, int::IntegratorHSPARKsecondary)
     print(io, "\nsubject to Dirac constraints with projection on secondary constraint *EXPERIMENTAL*\n")
     print(io, "   Timestep: $(timestep(int))\n")
     print(io, "   Tableau:  $(description(method(int)))\n")
-    print(io, "   $(string(method(int).q))")
-    print(io, "   $(string(method(int).p))")
+    print(io, "   $(string(tableau(method(int)).q))")
+    print(io, "   $(string(tableau(method(int)).p))")
     # print(io, reference(method(int)))
 end
 

--- a/src/spark/integrators_slrk.jl
+++ b/src/spark/integrators_slrk.jl
@@ -168,7 +168,7 @@ the momentum-stage equation instead — see `residual_correction!`.)
     gauge-equivalent `LotkaVolterra2d`. `SLRKLobattoIIID` and `SLRKLobattoIIIE` are
     full rank in both blocks and are the safest default.
 """
-const IntegratorSLRK{DT,TT} = GeometricIntegrator{<:LDAEProblem{DT,TT},<:SLRK}
+const IntegratorSLRK{DT,TT} = GeometricIntegrator{<:SLRK,<:LDAEProblem{DT,TT}}
 
 
 function Base.show(io::IO, int::IntegratorSLRK)
@@ -176,8 +176,8 @@ function Base.show(io::IO, int::IntegratorSLRK)
     print(io, "\nvariational systems with projection on secondary constraint:\n")
     print(io, "   Timestep: $(timestep(int))\n")
     print(io, "   Tableau:  $(description(method(int)))\n")
-    print(io, "   $(string(method(int).q))")
-    print(io, "   $(string(method(int).p))")
+    print(io, "   $(string(tableau(method(int)).q))")
+    print(io, "   $(string(tableau(method(int)).p))")
     # print(io, reference(method(int)))
 end
 

--- a/src/spark/integrators_spark.jl
+++ b/src/spark/integrators_spark.jl
@@ -63,14 +63,14 @@ p_{n+1} &= p_{n} + h \sum \limits_{i=1}^{s} b_{i} F_{n,i} + h \sum \limits_{i=1}
 \end{aligned}
 ```
 """
-const IntegratorSPARK{DT,TT} = GeometricIntegrator{<:Union{IDAEProblem{DT,TT},LDAEProblem{DT,TT}},<:SPARKMethod}
+const IntegratorSPARK{DT,TT} = GeometricIntegrator{<:SPARKMethod,<:Union{IDAEProblem{DT,TT},LDAEProblem{DT,TT}}}
 
 function Base.show(io::IO, int::IntegratorSPARK)
     print(io, "\nSpecialised Partitioned Additive Runge-Kutta integrator for index-two DAE systems:\n")
     print(io, "   Timestep: $(timestep(int))\n")
     print(io, "   Tableau:  $(description(method(int)))\n")
-    print(io, "   $(string(method(int).q))")
-    print(io, "   $(string(method(int).p))")
+    print(io, "   $(string(tableau(method(int)).q))")
+    print(io, "   $(string(tableau(method(int)).p))")
     # print(io, reference(method(int)))
 end
 

--- a/src/spark/integrators_vpark.jl
+++ b/src/spark/integrators_vpark.jl
@@ -49,8 +49,8 @@ function Base.show(io::IO, int::IntegratorVPARK)
     print(io, "\nVariational partitioned additive Runge-Kutta integrator:\n")
     print(io, "   Timestep: $(timestep(int))\n")
     print(io, "   Tableau:  $(description(method(int)))\n")
-    print(io, "   $(string(method(int).q))")
-    print(io, "   $(string(method(int).p))")
+    print(io, "   $(string(tableau(method(int)).q))")
+    print(io, "   $(string(tableau(method(int)).p))")
     # print(io, reference(method(int)))
 end
 

--- a/src/spark/integrators_vspark.jl
+++ b/src/spark/integrators_vspark.jl
@@ -51,8 +51,8 @@ function Base.show(io::IO, int::IntegratorVSPARK)
     print(io, "\nSpecialised Partitioned Additive Runge-Kutta integrator for Variational systems:\n")
     print(io, "   Timestep: $(timestep(int))\n")
     print(io, "   Tableau:  $(description(method(int)))\n")
-    print(io, "   $(string(method(int).q))")
-    print(io, "   $(string(method(int).p))")
+    print(io, "   $(string(tableau(method(int)).q))")
+    print(io, "   $(string(tableau(method(int)).p))")
     # print(io, reference(method(int)))
 end
 

--- a/src/spark/integrators_vspark_primary.jl
+++ b/src/spark/integrators_vspark_primary.jl
@@ -121,8 +121,8 @@ function Base.show(io::IO, int::IntegratorVSPARKprimary)
     print(io, "\nwith projection on primary constraint:\n")
     print(io, "   Timestep: $(timestep(int))\n")
     print(io, "   Tableau:  $(description(method(int)))\n")
-    print(io, "   $(string(method(int).q))")
-    print(io, "   $(string(method(int).p))")
+    print(io, "   $(string(tableau(method(int)).q))")
+    print(io, "   $(string(tableau(method(int)).p))")
     # print(io, reference(method(int)))
 end
 

--- a/src/spark/integrators_vspark_secondary.jl
+++ b/src/spark/integrators_vspark_secondary.jl
@@ -102,8 +102,8 @@ function Base.show(io::IO, int::IntegratorVSPARKsecondary)
     print(io, "\nvariational systems with projection on secondary constraint:\n")
     print(io, "   Timestep: $(timestep(int))\n")
     print(io, "   Tableau:  $(description(method(int)))\n")
-    print(io, "   $(string(method(int).q))")
-    print(io, "   $(string(method(int).p))")
+    print(io, "   $(string(tableau(method(int)).q))")
+    print(io, "   $(string(tableau(method(int)).p))")
     # print(io, reference(method(int)))
 end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -13,5 +13,22 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SimpleSolvers = "36b790f5-6434-4fbe-b711-1f64a1e2f6a2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+# The bounds in the root Project.toml only constrain that project's own [deps]; the packages
+# listed there under [extras] are dependencies of *this* project, so they need bounds here to
+# constrain what the test environment resolves.
+[compat]
+Aqua = "0.8"
+CompactBasisFunctions = "0.2"
+GeometricEquations = "0.21"
+GeometricIntegratorsBase = "0.3, 0.4"
+GeometricProblems = "0.8"
+LinearAlgebra = "1"
+Logging = "1"
+QuadratureRules = "0.1"
+RungeKutta = "0.5.23"
+SafeTestsets = "0.1"
+SimpleSolvers = "0.9"
+Test = "1"
+
 [sources]
 GeometricIntegrators = {path = ".."}

--- a/test/integrators/test_show.jl
+++ b/test/integrators/test_show.jl
@@ -2,6 +2,7 @@ using GeometricIntegrators
 using GeometricProblems.HarmonicOscillator
 import GeometricProblems.LotkaVolterra2dSingular
 using RungeKutta.Tableaus: TableauCrouzeix
+using Test
 
 ode  = odeproblem()
 pode = podeproblem()
@@ -11,27 +12,6 @@ lode = lodeproblem()
 sode = sodeproblem()
 ldae = ldaeproblem()
 
-
-show(stdout, GeometricIntegrator(ode, ExplicitEuler()))
-show(stdout, GeometricIntegrator(ode, RK(TableauCrouzeix())))
-show(stdout, GeometricIntegrator(ode, ImplicitEuler()))
-
-show(stdout, GeometricIntegrator(pode, LobattoIIIAIIIB(2)))
-show(stdout, GeometricIntegrator(pode, Gauss(1)))
-
-show(stdout, GeometricIntegrator(iode, Gauss(1)))
-show(stdout, GeometricIntegrator(iode, LobattoIIIAIIIB(2)))
-
-show(stdout, GeometricIntegrator(iode, VPRK(Gauss(1))))
-show(stdout, GeometricIntegrator(iode, VPRKpInternal(Gauss(1))))
-show(stdout, GeometricIntegrator(iode, VPRKpMidpoint(Gauss(1))))
-show(stdout, GeometricIntegrator(ldae, VPRKpSecondary(Gauss(1))))
-show(stdout, GeometricIntegrator(iode, VPRKpStandard(Gauss(1))))
-show(stdout, GeometricIntegrator(iode, VPRKpSymmetric(Gauss(1))))
-show(stdout, GeometricIntegrator(iode, VPRKpVariational(Gauss(1))))
-
-show(stdout, GeometricIntegrator(lode, FLRK(Gauss(1))))
-
 # The degenerate variational integrators need an even-dimensional configuration
 # space: they split the coordinates into the half that carries the quadrature
 # update and the half determined by the constraint p = ϑ(q). The harmonic
@@ -39,9 +19,58 @@ show(stdout, GeometricIntegrator(lode, FLRK(Gauss(1))))
 # defined and the cache constructors now throw, so use an in-class 2d problem here.
 dvilode = LotkaVolterra2dSingular.lodeproblem()
 
-show(stdout, GeometricIntegrator(dvilode, DVIA()))
-show(stdout, GeometricIntegrator(dvilode, DVIB()))
-show(stdout, GeometricIntegrator(dvilode, CMDVI()))
-show(stdout, GeometricIntegrator(dvilode, CTDVI()))
 
-show(stdout, GeometricIntegrator(dvilode, DVRK(Gauss(1))))
+# The `show` methods are captured with `sprint` rather than written to `stdout`:
+# their output is verbose (tableaus, coefficients, literature references) and would
+# otherwise bury the test summary. Asserting a non-empty result keeps the smoke test
+# honest — a `show` method printing nothing at all now fails instead of passing
+# silently.
+@testset "$(rpad("Show Methods and Integrators",80))" begin
+
+    # the methods themselves: one per family with a `show` method of its own
+    # (`RKMethod` and `PRKMethod` in src/integrators/rk/abstract.jl, `VPRKMethod` in
+    # src/integrators/vi/vprk_methods.jl). The Galerkin methods `CGVI` and `DGVIMethod`
+    # also define `show`, but constructing them needs a basis and a quadrature rule;
+    # they are left to the Galerkin tests.
+    @test length(sprint(show, ExplicitEuler())) > 0
+    @test length(sprint(show, RK(TableauCrouzeix()))) > 0
+    @test length(sprint(show, Gauss(1))) > 0
+    @test length(sprint(show, LobattoIIIAIIIB(2))) > 0
+    @test length(sprint(show, VPRK(Gauss(1)))) > 0
+    @test length(sprint(show, VPRKpMidpoint(Gauss(1)))) > 0
+
+    # the integrators
+    @test length(sprint(show, GeometricIntegrator(ode, ExplicitEuler()))) > 0
+    @test length(sprint(show, GeometricIntegrator(ode, RK(TableauCrouzeix())))) > 0
+    @test length(sprint(show, GeometricIntegrator(ode, ImplicitEuler()))) > 0
+
+    @test length(sprint(show, GeometricIntegrator(pode, LobattoIIIAIIIB(2)))) > 0
+    @test length(sprint(show, GeometricIntegrator(pode, Gauss(1)))) > 0
+
+    @test length(sprint(show, GeometricIntegrator(hode, SymplecticEulerA()))) > 0
+    @test length(sprint(show, GeometricIntegrator(hode, Gauss(1)))) > 0
+
+    @test length(sprint(show, GeometricIntegrator(sode, LieA()))) > 0
+    @test length(sprint(show, GeometricIntegrator(sode, Composition(Strang())))) > 0
+
+    @test length(sprint(show, GeometricIntegrator(iode, Gauss(1)))) > 0
+    @test length(sprint(show, GeometricIntegrator(iode, LobattoIIIAIIIB(2)))) > 0
+
+    @test length(sprint(show, GeometricIntegrator(iode, VPRK(Gauss(1))))) > 0
+    @test length(sprint(show, GeometricIntegrator(iode, VPRKpInternal(Gauss(1))))) > 0
+    @test length(sprint(show, GeometricIntegrator(iode, VPRKpMidpoint(Gauss(1))))) > 0
+    @test length(sprint(show, GeometricIntegrator(ldae, VPRKpSecondary(Gauss(1))))) > 0
+    @test length(sprint(show, GeometricIntegrator(iode, VPRKpStandard(Gauss(1))))) > 0
+    @test length(sprint(show, GeometricIntegrator(iode, VPRKpSymmetric(Gauss(1))))) > 0
+    @test length(sprint(show, GeometricIntegrator(iode, VPRKpVariational(Gauss(1))))) > 0
+
+    @test length(sprint(show, GeometricIntegrator(lode, FLRK(Gauss(1))))) > 0
+
+    @test length(sprint(show, GeometricIntegrator(dvilode, DVIA()))) > 0
+    @test length(sprint(show, GeometricIntegrator(dvilode, DVIB()))) > 0
+    @test length(sprint(show, GeometricIntegrator(dvilode, CMDVI()))) > 0
+    @test length(sprint(show, GeometricIntegrator(dvilode, CTDVI()))) > 0
+
+    @test length(sprint(show, GeometricIntegrator(dvilode, DVRK(Gauss(1))))) > 0
+
+end

--- a/test/integrators/test_show.jl
+++ b/test/integrators/test_show.jl
@@ -1,6 +1,10 @@
 using GeometricIntegrators
+using GeometricIntegrators.SPARK
 using GeometricProblems.HarmonicOscillator
+import GeometricProblems.LotkaVolterra2d as LotkaVolterra2d
 import GeometricProblems.LotkaVolterra2dSingular
+using CompactBasisFunctions
+using QuadratureRules
 using RungeKutta.Tableaus: TableauCrouzeix
 using Test
 
@@ -19,58 +23,157 @@ ldae = ldaeproblem()
 # defined and the cache constructors now throw, so use an in-class 2d problem here.
 dvilode = LotkaVolterra2dSingular.lodeproblem()
 
+# The Galerkin methods need a basis and a quadrature rule, the DGVIs additionally a
+# fully degenerate Lagrangian, and the SPARK methods a DAE formulation — the same
+# constructions as in test/integrators/galerkin_integrators_tests.jl and
+# test/spark/spark_integrators_tests.jl.
+QGau4 = GaussLegendreQuadrature(4)
+BGau4 = Lagrange(QuadratureRules.nodes(QGau4))
+dgjump = Discontinuity(PathIntegralLinear(), LobattoLegendreQuadrature(2))
 
-# The `show` methods are captured with `sprint` rather than written to `stdout`:
-# their output is verbose (tableaus, coefficients, literature references) and would
-# otherwise bury the test summary. Asserting a non-empty result keeps the smoke test
-# honest — a `show` method printing nothing at all now fails instead of passing
-# silently.
+const lv_q₀ = [1.0, 1.0]
+const lv_params = (a₁=1.0, a₂=1.0, b₁=-1.0, b₂=-2.0)
+const lv_tspan = (0.0, 0.1)
+const lv_Δt = 0.01
+
+lvargs = (timespan=lv_tspan, timestep=lv_Δt, parameters=lv_params)
+
+dgiode = LotkaVolterra2d.iodeproblem_dg(lv_q₀; lvargs...)
+lvidae = LotkaVolterra2d.idaeproblem(lv_q₀; lvargs...)
+lvldae = LotkaVolterra2d.ldaeproblem(lv_q₀; lvargs...)
+lvpdae = LotkaVolterra2d.pdaeproblem(lv_q₀; lvargs...)
+lvhdae = LotkaVolterra2d.hdaeproblem(lv_q₀; lvargs...)
+lvslrk = LotkaVolterra2d.ldaeproblem_slrk(lv_q₀; lvargs...)
+
+# The `show` output is captured with `sprint` rather than written to `stdout`: it is
+# verbose (tableaus, coefficients, literature references) and would otherwise bury the
+# test summary. Where the object carries a `show` method of its own, its title line is
+# asserted, so that a method printing nothing — or Julia's default struct dump silently
+# standing in for a missing one — fails instead of passing.
+test_show(x, title) = @test occursin(title, sprint(show, x))
+
+# For objects without a specialised `show` all that can be checked is that the default
+# dump runs and produces output. They are listed separately below so the gaps stay
+# visible rather than hiding behind a non-emptiness check.
+test_show_default(x) = @test length(sprint(show, x)) > 0
+
+
 @testset "$(rpad("Show Methods and Integrators",80))" begin
 
-    # the methods themselves: one per family with a `show` method of its own
-    # (`RKMethod` and `PRKMethod` in src/integrators/rk/abstract.jl, `VPRKMethod` in
-    # src/integrators/vi/vprk_methods.jl). The Galerkin methods `CGVI` and `DGVIMethod`
-    # also define `show`, but constructing them needs a basis and a quadrature rule;
-    # they are left to the Galerkin tests.
-    @test length(sprint(show, ExplicitEuler())) > 0
-    @test length(sprint(show, RK(TableauCrouzeix()))) > 0
-    @test length(sprint(show, Gauss(1))) > 0
-    @test length(sprint(show, LobattoIIIAIIIB(2))) > 0
-    @test length(sprint(show, VPRK(Gauss(1)))) > 0
-    @test length(sprint(show, VPRKpMidpoint(Gauss(1)))) > 0
+    ### the methods themselves ###
 
-    # the integrators
-    @test length(sprint(show, GeometricIntegrator(ode, ExplicitEuler()))) > 0
-    @test length(sprint(show, GeometricIntegrator(ode, RK(TableauCrouzeix())))) > 0
-    @test length(sprint(show, GeometricIntegrator(ode, ImplicitEuler()))) > 0
+    # `RKMethod` and `PRKMethod` (src/integrators/rk/abstract.jl), `VPRKMethod`
+    # (src/integrators/vi/vprk_methods.jl), `CGVI` (src/integrators/cgvi/integrators_cgvi.jl)
+    # and `DGVIMethod` (src/integrators/dgvi/integrators_dgvi_common.jl) print their tableau
+    # or basis; the remaining method structs have no `show` of their own.
+    test_show(RK(TableauCrouzeix()), "Runge-Kutta Method with Tableau")
+    test_show(Gauss(1), "Runge-Kutta Method with Tableau")
+    test_show(LobattoIIIAIIIB(2), "Partitioned Runge-Kutta Method with Tableau")
+    test_show(VPRK(Gauss(1)), "Variational Partitioned Runge-Kutta Method with Tableau")
+    test_show(CGVI(BGau4, QGau4), "Continuous Galerkin Variational Integrator")
+    test_show(DGVI(BGau4, QGau4), "Discontinuous Galerkin Variational Integrator")
 
-    @test length(sprint(show, GeometricIntegrator(pode, LobattoIIIAIIIB(2)))) > 0
-    @test length(sprint(show, GeometricIntegrator(pode, Gauss(1)))) > 0
+    test_show_default(ExplicitEuler())
+    test_show_default(VPRKpMidpoint(Gauss(1)))
 
-    @test length(sprint(show, GeometricIntegrator(hode, SymplecticEulerA()))) > 0
-    @test length(sprint(show, GeometricIntegrator(hode, Gauss(1)))) > 0
 
-    @test length(sprint(show, GeometricIntegrator(sode, LieA()))) > 0
-    @test length(sprint(show, GeometricIntegrator(sode, Composition(Strang())))) > 0
+    ### the integrators ###
 
-    @test length(sprint(show, GeometricIntegrator(iode, Gauss(1)))) > 0
-    @test length(sprint(show, GeometricIntegrator(iode, LobattoIIIAIIIB(2)))) > 0
+    test_show(GeometricIntegrator(ode, RK(TableauCrouzeix())), "Diagonally Implicit Runge-Kutta Integrator")
+    test_show(GeometricIntegrator(ode, Gauss(1)), "Implicit Runge-Kutta Integrator")
+    test_show(GeometricIntegrator(ode, PGLRK(3)), "Projected Gauss-Legendre Runge-Kutta Integrator")
 
-    @test length(sprint(show, GeometricIntegrator(iode, VPRK(Gauss(1))))) > 0
-    @test length(sprint(show, GeometricIntegrator(iode, VPRKpInternal(Gauss(1))))) > 0
-    @test length(sprint(show, GeometricIntegrator(iode, VPRKpMidpoint(Gauss(1))))) > 0
-    @test length(sprint(show, GeometricIntegrator(ldae, VPRKpSecondary(Gauss(1))))) > 0
-    @test length(sprint(show, GeometricIntegrator(iode, VPRKpStandard(Gauss(1))))) > 0
-    @test length(sprint(show, GeometricIntegrator(iode, VPRKpSymmetric(Gauss(1))))) > 0
-    @test length(sprint(show, GeometricIntegrator(iode, VPRKpVariational(Gauss(1))))) > 0
+    test_show(GeometricIntegrator(pode, LobattoIIIAIIIB(2)), "Explicit Partitioned Runge-Kutta Integrator")
+    test_show(GeometricIntegrator(pode, Gauss(1)), "Implicit Partitioned Runge-Kutta Integrator")
 
-    @test length(sprint(show, GeometricIntegrator(lode, FLRK(Gauss(1))))) > 0
+    test_show(GeometricIntegrator(hode, SymplecticEulerA()), "Explicit Partitioned Runge-Kutta Integrator")
+    test_show(GeometricIntegrator(hode, Gauss(1)), "Implicit Partitioned Runge-Kutta Integrator")
 
-    @test length(sprint(show, GeometricIntegrator(dvilode, DVIA()))) > 0
-    @test length(sprint(show, GeometricIntegrator(dvilode, DVIB()))) > 0
-    @test length(sprint(show, GeometricIntegrator(dvilode, CMDVI()))) > 0
-    @test length(sprint(show, GeometricIntegrator(dvilode, CTDVI()))) > 0
+    test_show(GeometricIntegrator(iode, Gauss(1)), "Runge-Kutta Integrator for Implicit Equations")
+    test_show(GeometricIntegrator(iode, LobattoIIIAIIIB(2)), "Explicit Partitioned Runge-Kutta Integrator")
+    test_show(GeometricIntegrator(iode, VPRKpTableau(4)), "Variational Partitioned Runge-Kutta Integrator with Projection in the Tableau")
 
-    @test length(sprint(show, GeometricIntegrator(dvilode, DVRK(Gauss(1))))) > 0
+    test_show(GeometricIntegrator(lode, FLRK(Gauss(1))), "Formal Lagrangian Runge-Kutta Integrator")
+
+    test_show(GeometricIntegrator(lode, PMVImidpoint()), "Midpoint variational integrator in position-momentum form")
+    test_show(GeometricIntegrator(lode, PMVItrapezoidal()), "Trapezoidal variational integrator in position-momentum form")
+
+    # the Hamilton-Pontryagin integrators take the discrete velocity map and its
+    # derivatives, as in test/integrators/hamilton_pontryagin_integrators_tests.jl
+    ϕ(v, q̄, q, a, Δt) = v .= (q .- q̄) ./ Δt
+
+    function D₁ϕ(d, q̄, q, a, Δt)
+        d .= 0
+        for i in eachindex(q)
+            d[i, i] = -1 / Δt
+        end
+    end
+
+    function D₂ϕ(d, q̄, q, a, Δt)
+        d .= 0
+        for i in eachindex(q)
+            d[i, i] = +1 / Δt
+        end
+    end
+
+    Dₐϕ(d, q̄, q, a, Δt) = d .= 0
+
+    test_show(GeometricIntegrator(lode, HPImidpoint(ϕ, D₁ϕ, D₂ϕ, Dₐϕ, Float64[])), "Hamilton-Pontryagin Integrator using midpoint quadrature")
+    test_show(GeometricIntegrator(lode, HPItrapezoidal(ϕ, D₁ϕ, D₂ϕ, Dₐϕ, Float64[])), "Hamilton-Pontryagin Integrator using trapezoidal quadrature")
+
+    test_show(GeometricIntegrator(dgiode, DGVI(BGau4, QGau4)), "Discontinuous Galerkin Variational Integrator")
+    test_show(GeometricIntegrator(dgiode, DGVIPI(BGau4, QGau4, dgjump)), "Discontinuous Galerkin Variational Integrator")
+
+    test_show(GeometricIntegrator(dvilode, DVIA()), "Degenerate Variational Integrator (Euler-A)")
+    test_show(GeometricIntegrator(dvilode, DVIB()), "Degenerate Variational Integrator (Euler-B)")
+    test_show(GeometricIntegrator(dvilode, CMDVI()), "Midpoint Degenerate Variational Integrator")
+    test_show(GeometricIntegrator(dvilode, CTDVI()), "Trapezoidal Degenerate Variational Integrator")
+    test_show(GeometricIntegrator(dvilode, DVRK(Gauss(1))), "Runge-Kutta Integrator for Degenerate Lagrangians")
+
+
+    ### the SPARK integrators ###
+
+    # only constructed, never integrated, so none of the solver warnings the SPARK tests
+    # muffle can appear here. All ten print the tableau via `tableau(method(int)).q/.p`;
+    # spelling that `method(int).q` threw a `FieldError` for the seven method types that
+    # wrap their tableau instead of being one.
+    test_show(GeometricIntegrator(lvslrk, SLRKLobattoIIIAB(2)), "Specialised Partitioned Additive Runge-Kutta integrator for degenerate")
+    test_show(GeometricIntegrator(lvidae, SPARKGLRK(1)), "Specialised Partitioned Additive Runge-Kutta integrator for index-two DAE systems")
+    test_show(GeometricIntegrator(lvidae, TableauGausspSymplectic(1)), "Variational partitioned additive Runge-Kutta integrator")
+    test_show(GeometricIntegrator(lvidae, VSPARK(SPARKLobABC(3))), "Specialised Partitioned Additive Runge-Kutta integrator for Variational systems")
+    test_show(GeometricIntegrator(lvidae, TableauVSPARKGLRKpMidpoint(1)), "with projection on primary constraint")
+    test_show(GeometricIntegrator(lvldae, TableauVSPARKLobattoIIIAB(2)), "variational systems with projection on secondary constraint")
+    test_show(GeometricIntegrator(lvpdae, TableauHPARKGLRK(1)), "Partitioned Additive Runge-Kutta integrator for Hamiltonian systems subject")
+    test_show(GeometricIntegrator(lvpdae, HSPARK(SPARKGLRK(1))), "Specialised Partitioned Additive Runge-Kutta integrator for Hamiltonian systems *EXPERIMENTAL*")
+    test_show(GeometricIntegrator(lvpdae, TableauHSPARKGLRKpSymmetric(1)), "with projection on primary constraint *EXPERIMENTAL*")
+    test_show(GeometricIntegrator(lvhdae, TableauHSPARKLobattoIIIAB(2)), "subject to Dirac constraints with projection on secondary constraint")
+
+
+    ### integrators that fall back to Julia's default struct dump ###
+
+    # `ExplicitEuler` and `ImplicitEuler` are implemented in GeometricIntegratorsBase, and
+    # the `{<:ERK}` / `{<:IRK}` methods in src/integrators/rk/ do not cover them, because
+    # neither method is converted to `ERK`/`IRK` the way `Gauss` is.
+    test_show_default(GeometricIntegrator(ode, ExplicitEuler()))
+    test_show_default(GeometricIntegrator(ode, ImplicitEuler()))
+
+    # the splitting and composition integrators define no `show` at all
+    test_show_default(GeometricIntegrator(sode, LieA()))
+    test_show_default(GeometricIntegrator(sode, Composition(Strang())))
+
+    # `show` commented out in src/integrators/vprk/integrators_vprk_abstract.jl
+    test_show_default(GeometricIntegrator(iode, VPRK(Gauss(1))))
+
+    # the projected integrators: `show` commented out in
+    # src/projections/{midpoint,standard,symmetric}_projection.jl
+    test_show_default(GeometricIntegrator(iode, VPRKpInternal(Gauss(1))))
+    test_show_default(GeometricIntegrator(iode, VPRKpMidpoint(Gauss(1))))
+    test_show_default(GeometricIntegrator(ldae, VPRKpSecondary(Gauss(1))))
+    test_show_default(GeometricIntegrator(iode, VPRKpStandard(Gauss(1))))
+    test_show_default(GeometricIntegrator(iode, VPRKpSymmetric(Gauss(1))))
+    test_show_default(GeometricIntegrator(iode, VPRKpVariational(Gauss(1))))
+
+    # `CGVI` defines `show` for the method (asserted above), not for the integrator
+    test_show_default(GeometricIntegrator(iode, CGVI(BGau4, QGau4)))
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,13 +46,6 @@ end
     include("projections/projections_vprk_tests.jl")
 end
 
-@safetestset "Ensemble Integrator Tests                                                       " begin
-    include("integrators/ensemble_integrators_tests.jl")
-end
-@safetestset "Show Methods and Integrators                                                    " begin
-    include("integrators/test_show.jl")
-end
-
 @safetestset "Convergence: Runge-Kutta                                                        " begin
     include("verification/rk_convergence_tests.jl")
 end
@@ -92,6 +85,12 @@ end
 
 @safetestset "Method Tests                                                                    " begin
     include("methods/methods_tests.jl")
+end
+@safetestset "Show Methods and Integrators                                                    " begin
+    include("integrators/test_show.jl")
+end
+@safetestset "Ensemble Integrator Tests                                                       " begin
+    include("integrators/ensemble_integrators_tests.jl")
 end
 @safetestset "Simulation Tests                                                                " begin
     include("simulations/simulations_tests.jl")

--- a/test/spark/spark_integrators_tests.jl
+++ b/test/spark/spark_integrators_tests.jl
@@ -34,13 +34,6 @@ ref = integrate(ode, Gauss(8))
 # keeps its own Options and never sees a `verbosity` kwarg passed through integrate.
 muffle(f) = Base.CoreLogging.with_logger(f, Base.CoreLogging.NullLogger())
 
-# Benign counterpart: VSPARK(SPARKLobABD(4)) stalls at one step just above machine
-# precision under the default f_abstol = 8eps(); relaxing it to 4e-15 makes the
-# solve converge and removes the warnings with the error unchanged. The other SPARK
-# defaults (see src/spark/abstract.jl) are repeated because passing any solver
-# option replaces the whole default_options bundle.
-const SPARK_RELAXED = (min_iterations = 1, x_suctol = 2eps(), f_abstol = 4e-15, f_suctol = 2eps())
-
 
 @testset "$(rpad("SLRK integrators",80))" begin
 
@@ -352,7 +345,12 @@ end
     sol = muffle(() -> integrate(idae, VSPARK(SPARKLobABD(3))))
     @test relative_maximum_error(sol.q, ref.q) < 8E-6
 
-    sol = integrate(idae, VSPARK(SPARKLobABD(4)); SPARK_RELAXED...)
+    # converges to 5.2E-12, but the line search stalls at one step just above machine
+    # precision and warns. Relaxing f_abstol to 4e-15 (the former workaround, a
+    # SPARK_RELAXED option bundle here) no longer removes the warning under
+    # SimpleSolvers 0.9.2 — it turns one warning into twelve at unchanged error — so
+    # the framework defaults are kept and the warning is muffled like the others.
+    sol = muffle(() -> integrate(idae, VSPARK(SPARKLobABD(4))))
     @test relative_maximum_error(sol.q, ref.q) < 1E-11
 
 


### PR DESCRIPTION
## Summary

This branch moves the package to **GeometricProblems 0.8** (`d7b156d1`), gives every dependency a
compat entry (`fd31d473`) and puts those bounds where they are actually resolved (`35f7a367`), and
tidies the CTDVI initial guess (`437dc2a9`). On top of that, three commits remove the remaining noise
from the test output and make the `show` smoke test assert something.

### The CTDVI initial guess

`437dc2a9` makes the last two `cache(int).x[…]` accesses in `initial_guess!` use the
`x = nlsolution(int)` alias the function already binds two lines earlier. `nlsolution(int)` *is*
`cache(int).x` for `CTDVICache`, so this is a consistency cleanup with no behaviour change — the
commit title ("Minor fix") overstates it.

### Silence the `show` tests

`test/integrators/test_show.jl` called `show(stdout, ...)` on 20 integrators, so every run dumped
their full descriptions — tableaus, coefficients, literature references, and the default struct dump
for those without a specialised `show` method — over the test summary. The file also contained no
`@test` at all: the safetestset reported zero tests, and a `show` method printing nothing would have
passed.

Output is now captured with `sprint`, the pattern already used in
`test/methods/method_list_tests.jl`. All `Base.show` methods in `src/` print to their `io` argument,
so nothing leaks to stdout. The file also lives up to its name — it shows the method objects
themselves (`RKMethod`, `PRKMethod`, `VPRKMethod`), and covers the `hode` / `sode` problems it
previously constructed but never used.

### Muffle the last warning source in the SPARK tests, drop `SPARK_RELAXED`

Attributing each `@warn` to its test line (a logger capturing `stacktrace()` around the suite) shows
exactly one un-muffled warning source left: the twelve backtracking line-search warnings all came
from the `VSPARK(SPARKLobABD(4))` call.

That call is the one 221ce2c0 tuned rather than muffled, because relaxing `f_abstol` to `4e-15`
removed its warnings at the time. The line search has since been reworked and the tuning is now
counterproductive:

| options | warnings | error |
|---|---|---|
| `SPARK_RELAXED` (`f_abstol = 4e-15`) | 12 | 5.2039e-12 |
| framework defaults | 1 | 5.2034e-12 |

So the `SPARK_RELAXED` bundle is dropped, the plain call restored, and the warning muffled like its
neighbours. `docs/src/audit.md` recorded the old measurements as if they still held, so the new ones
are noted there.

### Fix the SPARK `show` methods, and assert titles in the show tests

Asserting only that `sprint(show, x)` is non-empty cannot fail for an object that falls back to
Julia's default struct dump. Asserting the title line instead (`bb701a0a`) surfaced ten broken
`Base.show` methods in `src/spark/`:

* Seven of them threw. `SPARK`, `VPARK`, `VSPARK`, `VSPARKprimary`, `HPARK`, `HSPARK` and
  `HSPARKprimary` wrap their tableau (`tableau(method) = method.tableau`), so printing the
  coefficients as `method(int).q` raised `FieldError: type VSPARK has no field q`. The three method
  types that *are* their own tableau (`SLRK`, `VSPARKsecondary`, `HSPARKsecondary`) worked by
  accident; all ten now use `tableau(method(int)).q`, correct either way.
* `IntegratorSPARK` and `IntegratorSLRK` had their type parameters swapped —
  `GeometricIntegrator{<:LDAEProblem{DT,TT},<:SLRK}` for a struct declared
  `GeometricIntegrator{MT<:GeometricMethod,PT<:AbstractProblem,...}`. Both aliases were therefore
  uninhabited and their `show` methods dead code: showing an SLRK integrator produced a
  41834-character default dump in place of its 308-character description, and a SPARK one 27976
  characters. Both aliases are exported and carry `@ref` entries in
  `docs/src/integrators/spark.md`.

Coverage grows from the RK/VPRK/DVI families to `PGLRK`, the position-momentum and
Hamilton-Pontryagin integrators, `VPRKpTableau`, the `CGVI`/`DGVIMethod` method objects, the DGVI
integrators and all ten SPARK integrators — constructed only, never integrated, so no solver
warnings appear. The cases that do fall back to the default dump keep a non-emptiness check in a
separate group that names the reason for each, so the gaps stay visible.

### Bound the test and docs dependencies where they are resolved

The root `[compat]` entries for `GeometricProblems`, `Aqua` and `SafeTestsets` satisfy Aqua's
`Compat bounds` check, but they constrain nothing: those packages are not dependencies of the root
project, they are dependencies of the workspace members `test/` and `docs/`, and Pkg enforces a
project's compat only for its own deps. Neither member had a `[compat]` section, so the
GeometricProblems 0.8 bound could not stop either environment from resolving 0.7.x — the fresh
`Pkg.test` environment picked 0.8.0 because it is the newest release. `35f7a367` adds `[compat]` to
both members and leaves the root entries alone. In a scratch environment holding a copy of
`test/Project.toml`, `Pkg.add(name="GeometricProblems", version="0.7.4")` succeeded before that
commit and now fails with `empty intersection between GeometricProblems@0.7.4 and project
compatibility 0.8`; `Pkg.resolve()` reports no change to the manifest.

## Test plan

- Full suite green via the `pre-push` hook: 28 testsets, **1488 pass / 66 pre-existing
  `@test_broken`**, no failures and **no warnings anywhere in the log**.
- SPARK suite is warning-free (empty stderr, was 12 warnings) with the tally unchanged at **174 pass
  / 45 broken**, testset by testset.
- `Show Methods and Integrators`: **52 pass**, no output.
- `test/runaqua.jl`: all five testsets pass, `Compat bounds` 4/4 (was 2 pass / 2 fail before
  `fd31d473`). Note that `runaqua.jl` is not included in `runtests.jl`, so CI never runs it.
- `doctest(GeometricIntegrators)` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
